### PR TITLE
Sign a PDF and get a PDF back

### DIFF
--- a/App/Document/DrawingDocument.swift
+++ b/App/Document/DrawingDocument.swift
@@ -19,6 +19,17 @@ final class DrawingDocument: NSDocument {
     /// way instead of silently converting the user's PNG into something else.
     private var sourceFormat: ImageCodec.Format?
 
+    /// The PDF this document came from, when it came from one: the whole file,
+    /// which page of it is on the canvas, and the size that page is printed at.
+    /// Save writes the page back into it rather than replacing the document with
+    /// one flat picture.
+    private var pdfSource: PDFCodec.Source?
+
+    /// The export panel's own job is built outside `write(to:ofType:)`, so the
+    /// test that proves an exported page keeps its printed size needs the source
+    /// the same way the panel gets it.
+    var pdfSourceForTesting: PDFCodec.Source? { pdfSource }
+
     /// Kept so it can be torn down: without this, every document ever opened
     /// leaves an entry in the notification centre for the life of the process.
     ///
@@ -54,6 +65,9 @@ final class DrawingDocument: NSDocument {
         }
         model.onDuplicate = { [weak self] in
             _ = try? self?.duplicate()
+        }
+        model.onTurnToPage = { [weak self] index in
+            self?.turnToPage(index)
         }
         syncDocumentIdentity()
     }
@@ -255,17 +269,74 @@ final class DrawingDocument: NSDocument {
         // Decode first, off the model entirely: a failed read must leave the
         // open document untouched rather than half-replaced.
         let isPackage = typeName == Self.packageType || url.pathExtension.lowercased() == "itspaint"
+        let format = isPackage ? nil : ImageCodec.Format.inferred(from: url)
+
+        // A PDF arrives as a page and a way back to the file it came from. The
+        // whole file is kept, because saving has to put the other pages back —
+        // signing page four of a lease must not cost anyone pages one to three.
+        if format == .pdf {
+            let page = try PDFCodec.open(contentsOf: url)
+            MainActor.assumeIsolated {
+                sourceFormat = .pdf
+                pdfSource = page.source
+                model.pdfPage = (index: page.source.pageIndex, count: page.source.pageCount)
+                model.load(canvas: page.bitmap, metadata: nil)
+            }
+            return
+        }
+
         let contents = isPackage
             ? try Self.readPackage(at: url)
             : (canvas: try ImageCodec.decode(contentsOf: url), metadata: nil)
-        let format = isPackage ? nil : ImageCodec.Format.inferred(from: url)
 
         MainActor.assumeIsolated {
             sourceFormat = format
+            pdfSource = nil
+            model.pdfPage = nil
             // Loaded into the existing model rather than a fresh one: Revert to
             // Saved reads into a document whose window already captured this
             // object, so replacing it would leave the old pixels on screen.
             model.load(canvas: contents.canvas, metadata: contents.metadata)
+        }
+    }
+
+    // MARK: - Pages
+
+    /// Turn to another page of the PDF this document was opened from.
+    ///
+    /// The current page's edits are folded back into the in-memory file first,
+    /// so a signature on page four is still there when you come back from page
+    /// five. Undo does not cross the page boundary — the canvas is genuinely a
+    /// different image — which is why the fold happens here rather than at save
+    /// time: the alternative is losing the signature to a page turn.
+    private func turnToPage(_ index: Int) {
+        guard let source = pdfSource, index != source.pageIndex,
+              index >= 0, index < source.pageCount
+        else { return }
+
+        do {
+            let folded = try PDFCodec.encode(model.canvas, replacing: source)
+            let page = try PDFCodec.open(
+                data: folded,
+                page: index,
+                named: displayName.isEmpty ? "This document" : displayName
+            )
+            pdfSource = page.source
+            model.pdfPage = (index: page.source.pageIndex, count: page.source.pageCount)
+            model.load(canvas: page.bitmap, metadata: nil)
+            // **The history does not cross the page boundary.** Every registered
+            // undo replays a bitmap edit onto whatever canvas is loaded, so an
+            // undo left over from page four would paint page four's pixels onto
+            // page five. Revert to Saved clears the stack for the same reason.
+            undoManager?.removeAllActions()
+            // The fold is a real change to the file even though the visible
+            // page has only been swapped, so the document is dirty until saved.
+            updateChangeCount(.changeDone)
+        } catch {
+            model.present(
+                message: error.localizedDescription,
+                recovery: (error as? LocalizedError)?.recoverySuggestion
+            )
         }
     }
 
@@ -385,6 +456,7 @@ final class DrawingDocument: NSDocument {
         let background: PaintColour
         let palette: Palette
         let sourceFormat: ImageCodec.Format?
+        let pdfSource: PDFCodec.Source?
     }
 
     nonisolated private func makeWriteSnapshot() -> WriteSnapshot {
@@ -394,7 +466,8 @@ final class DrawingDocument: NSDocument {
                 foreground: model.foreground,
                 background: model.background,
                 palette: model.palette,
-                sourceFormat: sourceFormat
+                sourceFormat: sourceFormat,
+                pdfSource: pdfSource
             )
         }
     }
@@ -412,7 +485,12 @@ final class DrawingDocument: NSDocument {
             snapshot.canvas,
             to: url,
             as: format,
-            matte: snapshot.background
+            matte: snapshot.background,
+            // Saving a PDF puts the edited page back into the document it came
+            // from. Only when it *is* the same document: Save As to a different
+            // PDF gets the same treatment, which is what someone signing a copy
+            // of a contract means by "save as signed.pdf".
+            pdfSource: format == .pdf ? snapshot.pdfSource : nil
         )
     }
 
@@ -531,6 +609,11 @@ final class DrawingDocument: NSDocument {
         guard let window = windowControllers.first?.window else { return }
 
         let options = ExportOptions()
+        // A document that came from a PDF exports as one by default. Offering
+        // PNG first to someone who has just signed a contract is offering to
+        // throw the other pages away.
+        if pdfSource != nil { options.format = .pdf }
+
         let panel = NSSavePanel()
         panel.allowedContentTypes = [options.format.utType]
         panel.nameFieldStringValue = (displayName as NSString).deletingPathExtension
@@ -553,7 +636,8 @@ final class DrawingDocument: NSDocument {
             guard response == .OK, let url = panel.url, let self else { return }
             let job = options.job(
                 canvas: self.model.canvas,
-                matte: self.model.background
+                matte: self.model.background,
+                pdfSource: self.pdfSource
             )
             Task { @MainActor [weak self] in
                 let failure = await Task.detached(priority: .userInitiated) {
@@ -563,7 +647,10 @@ final class DrawingDocument: NSDocument {
                     } catch {
                         return ExportFailure(
                             message: error.localizedDescription,
-                            recovery: (error as? ImageCodec.CodecError)?.recoverySuggestion
+                            // Any `LocalizedError`, not just the image codec's:
+                            // PDF failures carry their own next step, and
+                            // dropping it left the alert as a dead end.
+                            recovery: (error as? LocalizedError)?.recoverySuggestion
                         )
                     }
                 }.value
@@ -634,6 +721,9 @@ struct ExportJob: Sendable {
     let scale: Double
     let quality: Double
     let matte: PaintColour
+    /// Set when the document was opened from a PDF, so exporting one keeps the
+    /// document's other pages and its page size.
+    var pdfSource: PDFCodec.Source?
 
     func scaledCanvas() throws -> Bitmap {
         guard scale != 1 else { return canvas }
@@ -667,7 +757,8 @@ struct ExportJob: Sendable {
             to: url,
             as: format,
             quality: quality,
-            matte: matte
+            matte: matte,
+            pdfSource: format == .pdf ? pdfSource?.resampled(by: scale) : nil
         )
     }
 }
@@ -689,13 +780,16 @@ final class ExportOptions {
     var scale: Double = 1
     var quality: Double = 0.9
 
-    func job(canvas: Bitmap, matte: PaintColour) -> ExportJob {
+    func job(
+        canvas: Bitmap, matte: PaintColour, pdfSource: PDFCodec.Source? = nil
+    ) -> ExportJob {
         ExportJob(
             canvas: canvas,
             format: format,
             scale: scale,
             quality: quality,
-            matte: matte
+            matte: matte,
+            pdfSource: pdfSource
         )
     }
 

--- a/App/Model/EditorModel.swift
+++ b/App/Model/EditorModel.swift
@@ -745,6 +745,27 @@ final class EditorModel {
 
     func duplicateDocument() { onDuplicate?() }
 
+    // MARK: - Paper
+
+    /// Which page of a PDF is on the canvas, when the document came from one.
+    ///
+    /// `nil` for everything else, which is what the chrome keys the page control
+    /// off: a screenshot has no pages and should not be told it is on page one
+    /// of one.
+    var pdfPage: (index: Int, count: Int)?
+
+    /// Hook the document installs so the header can turn a page. Zero-based, and
+    /// the document is the one that folds the current page's edits back into the
+    /// file before moving.
+    @ObservationIgnored var onTurnToPage: ((Int) -> Void)?
+
+    func turnToPage(_ index: Int) {
+        guard let page = pdfPage, index != page.index,
+              index >= 0, index < page.count
+        else { return }
+        onTurnToPage?(index)
+    }
+
     /// Live size of whatever region is being dragged, for the status bar.
     var activeRegionSize: (width: Int, height: Int)? { engine.activeRegionSize }
 
@@ -886,6 +907,15 @@ final class EditorModel {
 
     var isRotateSheetPresented: Bool = false
     var isSignatureSheetPresented: Bool = false
+
+    /// Duplicate asks first.
+    ///
+    /// The button is two overlapping pages beside Share, and pressing it used to
+    /// put a second untitled window on screen with no warning — indistinguishable
+    /// from having lost your place in the one you were working in. The menu item
+    /// says the word "Duplicate", so it still goes straight through; a glyph
+    /// cannot say it, so the glyph asks.
+    var isDuplicateConfirmationPresented: Bool = false
 
     func resizeCanvas(width: Int, height: Int) {
         guard Bitmap.isSizeSupported(width: width, height: height) else {

--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -87,6 +87,26 @@
 			<key>NSDocumentClass</key>
 			<string>$(PRODUCT_MODULE_NAME).DrawingDocument</string>
 		</dict>
+		<dict>
+			<!--
+			  PDF is declared separately, and deliberately as Viewer-rank
+			  Alternate: opening a page turns it into pixels to draw on, which is
+			  right for signing a form and wrong for being the Mac's default PDF
+			  app. Preview keeps that job.
+			-->
+			<key>CFBundleTypeName</key>
+			<string>PDF Document</string>
+			<key>CFBundleTypeRole</key>
+			<string>Editor</string>
+			<key>LSHandlerRank</key>
+			<string>Alternate</string>
+			<key>LSItemContentTypes</key>
+			<array>
+				<string>com.adobe.pdf</string>
+			</array>
+			<key>NSDocumentClass</key>
+			<string>$(PRODUCT_MODULE_NAME).DrawingDocument</string>
+		</dict>
 	</array>
 
 	<key>UTExportedTypeDeclarations</key>

--- a/App/UI/CanvasOverlays.swift
+++ b/App/UI/CanvasOverlays.swift
@@ -260,7 +260,9 @@ struct ZoomReadout: View {
     let isActualSize: Bool
     let action: () -> Void
 
+    @Environment(TooltipController.self) private var tooltips
     @State private var isHovering = false
+    @State private var frame: CGRect = .zero
 
     var body: some View {
         Button(action: action) {
@@ -277,9 +279,23 @@ struct ZoomReadout: View {
         }
         .buttonStyle(.plain)
         .disabled(isActualSize)
-        .onHover { isHovering = $0 }
+        .trackedForTooltip($frame)
+        .onHover { hovering in
+            isHovering = hovering
+            // The same chip its neighbours use. Two glyphs with the fast tooltip
+            // and the control between them on the system's slow one is the kind
+            // of seam you notice without being able to name.
+            hovering
+                ? tooltips.hover(
+                    key: "header-zoom",
+                    title: isActualSize ? "Actual size" : "Back to actual size",
+                    shortcut: "⌘0",
+                    detail: isActualSize ? "Already at 100%" : nil,
+                    anchor: frame
+                )
+                : tooltips.endHover(key: "header-zoom")
+        }
         .animation(Tokens.Motion.micro, value: isHovering)
-        .help("Actual size (⌘0)")
         .accessibilityLabel("Zoom \(label), press for actual size")
     }
 }

--- a/App/UI/CanvasOverlays.swift
+++ b/App/UI/CanvasOverlays.swift
@@ -63,14 +63,26 @@ struct HeaderGroup<Content: View>: View {
 }
 
 /// One button inside a header group.
+///
+/// **The tooltip is the app's own chip, not the system's.** The header is nine
+/// unlabelled glyphs, and `.help` waits about a second before naming any of
+/// them — long enough that people click one to find out what it does. Two of
+/// them, the paste clipboard and the drag-out handle, were reported as
+/// unidentifiable for exactly that reason. The rail already had the fast chip;
+/// this is the header joining it.
 struct HeaderButton: View {
     let symbol: String
     let title: String
     var shortcut: String?
+    /// One line under the title, for the buttons whose glyph cannot carry the
+    /// whole idea on its own.
+    var detail: String?
     var isEnabled: Bool = true
     let action: () -> Void
 
+    @Environment(TooltipController.self) private var tooltips
     @State private var isHovering = false
+    @State private var frame: CGRect = .zero
 
     var body: some View {
         Button(action: action) {
@@ -86,10 +98,41 @@ struct HeaderButton: View {
         }
         .buttonStyle(.plain)
         .disabled(!isEnabled)
-        .onHover { isHovering = $0 }
+        .trackedForTooltip($frame)
+        .onHover { hovering in
+            isHovering = hovering
+            // Named even while disabled. "Nothing to paste" is the most useful
+            // thing the button can say, and it is dim exactly when it needs to
+            // say it.
+            hovering
+                ? tooltips.hover(
+                    key: "header-\(title)", title: title,
+                    shortcut: shortcut, detail: detail, anchor: frame
+                )
+                : tooltips.endHover(key: "header-\(title)")
+        }
         .animation(Tokens.Motion.micro, value: isHovering)
-        .help(shortcut.map { "\(title) (\($0))" } ?? title)
         .accessibilityLabel(title)
+    }
+}
+
+/// Report a control's position on screen, so the one shared tooltip chip can sit
+/// under the control that asked for it.
+///
+/// Screen coordinates rather than a named space: the header lives in an overlay
+/// inside a `ZStack` that also holds the canvas, and the chip is drawn by a
+/// different branch of that stack.
+extension View {
+    func trackedForTooltip(_ frame: Binding<CGRect>) -> some View {
+        background {
+            GeometryReader { proxy in
+                Color.clear
+                    .onAppear { frame.wrappedValue = proxy.frame(in: .global) }
+                    .onChange(of: proxy.frame(in: .global)) { _, new in
+                        frame.wrappedValue = new
+                    }
+            }
+        }
     }
 }
 
@@ -109,7 +152,9 @@ struct HeaderButton: View {
 struct DragOutHandle: View {
     @Bindable var model: EditorModel
 
+    @Environment(TooltipController.self) private var tooltips
     @State private var isHovering = false
+    @State private var frame: CGRect = .zero
 
     var body: some View {
         // Resolved before the gesture rather than inside it. `draggable` takes
@@ -134,17 +179,26 @@ struct DragOutHandle: View {
                     .fill(.primary.opacity(isHovering && payload != nil ? Tokens.Fill.hover : 0))
             }
             .contentShape(Rectangle())
+            .trackedForTooltip($frame)
             .onHover { hovering in
                 isHovering = hovering
+                // The chip names it in 300ms rather than the system's second,
+                // because this is the glyph people reported not recognising.
+                hovering
+                    ? tooltips.hover(
+                        key: "header-drag", title: "Drag image out",
+                        shortcut: nil,
+                        detail: "Pick the picture up and drop it into Slack, Mail or the Finder",
+                        anchor: frame
+                    )
+                    : tooltips.endHover(key: "header-drag")
                 guard payload != nil else { return }
-                // A grab cursor is the only thing that says "drag me" before
-                // anyone has tried. `.help` only appears after a hover delay, by
-                // which point they have usually clicked and given up.
+                // A grab cursor is the other half of the instruction: it says
+                // "drag me" before anyone has waited for any tooltip at all.
                 if hovering { NSCursor.openHand.push() } else { NSCursor.pop() }
             }
             .animation(Tokens.Motion.micro, value: isHovering)
             .modifier(DraggableIfAvailable(payload: payload))
-            .help("Drag the image into another app — Slack, Mail, the Finder")
             .accessibilityLabel("Drag image out")
     }
 }
@@ -230,6 +284,44 @@ struct ZoomReadout: View {
     }
 }
 
+/// Which page of a PDF is on the canvas, and the way to another one.
+///
+/// **Only for documents that have pages.** A screenshot does not, and telling
+/// someone they are on page one of one is noise in the one place the window is
+/// supposed to say what they are looking at.
+///
+/// Turning a page saves the current one back into the file first, so a signature
+/// is never lost by looking at the page after it. Undo does not follow — the
+/// canvas becomes a genuinely different image — and the chip below the title
+/// keeps saying "Edited" until the document is saved, which is the honest state.
+struct PageControl: View {
+    @Bindable var model: EditorModel
+
+    var body: some View {
+        if let page = model.pdfPage {
+            HeaderGroup {
+                HeaderButton(
+                    symbol: "chevron.left", title: "Previous page",
+                    isEnabled: page.index > 0
+                ) { model.turnToPage(page.index - 1) }
+
+                Text("Page \(page.index + 1) of \(page.count)")
+                    .font(.system(size: 11).monospacedDigit())
+                    .foregroundStyle(.primary.opacity(Tokens.Ink.regular))
+                    .padding(.horizontal, Tokens.Space.tight)
+                    .fixedSize()
+
+                HeaderButton(
+                    symbol: "chevron.right", title: "Next page",
+                    isEnabled: page.index + 1 < page.count
+                ) { model.turnToPage(page.index + 1) }
+            }
+            .accessibilityElement(children: .contain)
+            .accessibilityLabel("Page \(page.index + 1) of \(page.count)")
+        }
+    }
+}
+
 /// A hairline between two runs inside one group.
 struct HeaderDivider: View {
     var body: some View {
@@ -296,17 +388,31 @@ struct WorkingActions: View {
                     symbol: "scissors", title: "Cut",
                     shortcut: "⌘X", isEnabled: model.hasSelection
                 ) { model.cutSelection() }
+                // **Copy always copies something.** It used to go dim with
+                // nothing selected, which reads as "copying is unavailable" when
+                // the obvious thing to copy — the whole picture — is right
+                // there. With a selection it copies the selection; without one it
+                // copies the image, which is what ⌘C means in every viewer
+                // people arrive from.
                 HeaderButton(
-                    symbol: "square.on.square", title: "Copy",
-                    shortcut: "⌘C", isEnabled: model.hasSelection
-                ) { model.copySelection() }
+                    symbol: "square.on.square",
+                    title: model.hasSelection ? "Copy selection" : "Copy image",
+                    shortcut: "⌘C",
+                    detail: "Puts it on the clipboard, ready to paste anywhere"
+                ) {
+                    model.hasSelection ? model.copySelection() : model.copyWholeImage()
+                }
                 HeaderButton(
                     // `clipboard` when there is something on it, and the same
                     // glyph without its page when there is not — so the button
                     // says *why* it is unavailable rather than just being dim.
                     symbol: model.canPaste ? "doc.on.clipboard" : "clipboard",
                     title: model.canPaste ? "Paste image" : "Nothing to paste",
-                    shortcut: "⌘V", isEnabled: model.canPaste
+                    shortcut: "⌘V",
+                    detail: model.canPaste
+                        ? "Drops the clipboard onto the canvas, still movable"
+                        : "Copy an image somewhere first",
+                    isEnabled: model.canPaste
                 ) { model.paste() }
                 DragOutHandle(model: model)
             }
@@ -364,14 +470,52 @@ struct WorkingActions: View {
 struct DocumentActions: View {
     @Bindable var model: EditorModel
 
+    @Environment(TooltipController.self) private var tooltips
+    @State private var shareFrame: CGRect = .zero
+
     var body: some View {
         HeaderGroup {
+            // **Signing has a button now.** It lived only in the Tools menu
+            // under ⌃⌘S — a chord nothing else in the app uses — which made the
+            // one feature nobody would guess at the one feature the window never
+            // mentioned. It sits with Share rather than in the rail because it
+            // is not a tool: you reach for it once per document, next to the
+            // other things you do to a finished document.
+            HeaderButton(
+                symbol: "signature", title: "Signature",
+                shortcut: "⌃⌘S",
+                detail: "Sign here, or drop in a signature you have already saved"
+            ) {
+                model.isSignatureSheetPresented = true
+            }
+
+            HeaderDivider()
+
             // Share is in the File menu, but a markup app's whole purpose is
             // getting the result to someone else — burying its most common last
             // step one menu down is the wrong emphasis.
+            //
+            // The chip is layered over the AppKit button rather than replacing
+            // its own `toolTip`: hover tracking across a representable is not
+            // guaranteed, and the system tooltip underneath is the floor if it
+            // does not fire.
             ShareButton()
-            HeaderButton(symbol: "doc.on.doc", title: "Duplicate", shortcut: "⇧⌘S") {
-                model.duplicateDocument()
+                .trackedForTooltip($shareFrame)
+                .onHover { hovering in
+                    hovering
+                        ? tooltips.hover(
+                            key: "header-share", title: "Share",
+                            shortcut: nil,
+                            detail: "AirDrop, Mail, Messages — as a named file, not \"Image\"",
+                            anchor: shareFrame
+                        )
+                        : tooltips.endHover(key: "header-share")
+                }
+            HeaderButton(
+                symbol: "doc.on.doc", title: "Duplicate", shortcut: "⇧⌘S",
+                detail: "Opens a copy in a new window"
+            ) {
+                model.isDuplicateConfirmationPresented = true
             }
         }
     }

--- a/App/UI/DesignTokens.swift
+++ b/App/UI/DesignTokens.swift
@@ -48,6 +48,9 @@ enum Tokens {
         /// number is the difference between a panel and a stack of unrelated
         /// rows that happen to share a background.
         static let optionLabel: CGFloat = 42
+        /// `GeometryReader` offers only 10pt intrinsically, which is not enough
+        /// travel for a size mark when the bottom panel measures its own row.
+        static let horizontalMarkMinimum: CGFloat = 96
         /// An action button inside the options panel.
         static let pillAction: CGFloat = 26
         /// A tool cell in the rail.

--- a/App/UI/EditorView.swift
+++ b/App/UI/EditorView.swift
@@ -25,6 +25,8 @@ struct EditorView: View {
     /// The panel's measured length along the rail's axis, so it can be kept
     /// inside the window without guessing how tall its content is.
     @State private var panelSpan: CGFloat = 0
+    /// Width of the header's tooltip chip, so it can be kept inside the window.
+    @State private var headerTooltipWidth: CGFloat = 0
 
     var body: some View {
         ZStack {
@@ -49,6 +51,8 @@ struct EditorView: View {
 
             titleRow
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+
+            headerTooltip
                 // **Above the tool chrome, which is drawn after it.** Share is
                 // the one control in this row that is an NSViewRepresentable
                 // rather than a SwiftUI Button — it hosts a real NSButton so its
@@ -62,6 +66,31 @@ struct EditorView: View {
 
             readOutRow
                 .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottomTrailing)
+
+            // Which page of the PDF is on the canvas, in the same bottom-centre
+            // slot the paste bar uses.
+            //
+            // **Not in the header.** A letter page opens a window about 650pt
+            // wide, and at that width a fourth capsule in the title row pushed
+            // the filename out of it entirely — a document with no visible name
+            // is a worse trade than a page control that is not in the titlebar.
+            // Down here it has room, it is where Books and Preview put page
+            // navigation, and it is only ever on screen for documents that have
+            // pages at all. The paste bar wins the slot while something is
+            // floating, because turning the page is not what anyone is doing
+            // mid-paste.
+            if model.pdfPage != nil, !model.hasFloatingContent {
+                PageControl(model: model)
+                    .fixedSize()
+                    .padding(.bottom, model.chromeEdge.isVertical
+                        ? Tokens.Space.safeInset
+                        : Tokens.Space.safeInset + Tokens.Rail.thickness + Tokens.Space.base)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+                    // Out of the way of the stroke being drawn, exactly like the
+                    // paste bar: a signature often lands right where this sits.
+                    .opacity(model.isDragging ? 0 : 1)
+                    .animation(Tokens.Motion.micro, value: model.isDragging)
+            }
 
             // Bottom-centre, clear of the rail on either edge and of the
             // pointer read-out in the corner.
@@ -123,6 +152,15 @@ struct EditorView: View {
         }
         .sheet(isPresented: $model.isRotateSheetPresented) {
             RotateSheet(model: model)
+        }
+        .confirmationDialog(
+            "Duplicate this drawing?",
+            isPresented: $model.isDuplicateConfirmationPresented
+        ) {
+            Button("Duplicate") { model.duplicateDocument() }
+            Button("Cancel", role: .cancel) {}
+        } message: {
+            Text("A copy opens in a new window. This one is left exactly as it is.")
         }
         .alert(item: $model.presentedError) { error in
             Alert(
@@ -191,7 +229,10 @@ struct EditorView: View {
             }
         }
         .overlay(alignment: isVertical ? .topLeading : .bottomLeading) {
-            if tooltips.isVisible {
+            // Only for controls that have no anchor of their own — the rail's,
+            // whose geometry this offset already knows. A header button carries
+            // its position with it and is drawn by `headerTooltip` instead.
+            if tooltips.isVisible, tooltips.anchor == nil {
                 Tooltip(title: tooltips.title, shortcut: tooltips.shortcut, detail: tooltips.detail)
                     .offset(
                         x: isVertical ? Tokens.Rail.thickness + Tokens.Space.snug : 0,
@@ -379,6 +420,61 @@ struct EditorView: View {
     /// Traffic lights, a title worth reading, the cluster, and the document
     /// actions, with the gaps between them. Below this the cluster overlaps.
     private static let centredClusterMinimum: CGFloat = 940
+
+    /// The chip for a header control, under the control itself.
+    ///
+    /// The header's buttons cannot draw it themselves: their group clips to its
+    /// own capsule, so a chip inside one is a chip with its bottom half cut off.
+    /// They report where they are instead and it is drawn out here, still one
+    /// chip at a time — the rail's chip is suppressed while a header button owns
+    /// the tooltip, because two of them on screen is two answers to one question.
+    @ViewBuilder
+    private var headerTooltip: some View {
+        GeometryReader { proxy in
+            if tooltips.isVisible, let anchor = tooltips.anchor {
+                let container = proxy.frame(in: .global)
+                Tooltip(
+                    title: tooltips.title,
+                    shortcut: tooltips.shortcut,
+                    detail: tooltips.detail
+                )
+                .fixedSize()
+                .background {
+                    GeometryReader { chip in
+                        Color.clear
+                            .onAppear { headerTooltipWidth = chip.size.width }
+                            .onChange(of: chip.size.width) { _, new in
+                                headerTooltipWidth = new
+                            }
+                    }
+                }
+                .position(
+                    x: Self.tooltipCentre(
+                        under: anchor, in: container, chipWidth: headerTooltipWidth
+                    ),
+                    y: anchor.maxY - container.minY + Tokens.Space.comfortable
+                )
+                .allowsHitTesting(false)
+            }
+        }
+    }
+
+    /// Where the header's chip is centred: under the control, unless that would
+    /// hang it off an edge of the window.
+    ///
+    /// The trailing group is three glyphs from the right edge and its chips carry
+    /// a line of explanation, so centring on the glyph alone puts half the
+    /// sentence outside the window — a tooltip you cannot read is worse than no
+    /// tooltip, because it also covers the artwork.
+    static func tooltipCentre(under anchor: CGRect, in container: CGRect, chipWidth: CGFloat) -> CGFloat {
+        let half = chipWidth / 2
+        let inset = half + Tokens.Space.base
+        let wanted = anchor.midX - container.minX
+        // A chip wider than the window cannot be kept inside it; centre it and
+        // let both ends run out rather than pinning it to one edge.
+        guard container.width > inset * 2 else { return container.width / 2 }
+        return min(max(wanted, inset), container.width - inset)
+    }
 
     private var readOutRow: some View {
         PointerReadout(model: model)

--- a/App/UI/ToolOptions.swift
+++ b/App/UI/ToolOptions.swift
@@ -248,7 +248,7 @@ struct ToolOptions: View {
             if strokes {
                 OptionRow("Line") {
                     OptionSegment(selection: $model.strokeDash, options: Raster.Dash.allCases.map {
-                        .init(value: $0, symbol: $0.symbolName, help: $0.displayName)
+                        .init(value: $0, label: $0.controlGlyph, help: $0.displayName)
                     })
                 }
             }
@@ -401,6 +401,7 @@ struct ToolOptions: View {
             readout: "\(model.brushSize)",
             normal: Double(max(allowed.lowerBound, 2))
         )
+        .frame(minWidth: isVertical ? nil : Tokens.Size.horizontalMarkMinimum)
     }
 
     // MARK: - Selection
@@ -485,6 +486,16 @@ struct ToolOptions: View {
             .buttonStyle(.plain)
             .help(title)
             .accessibilityLabel(title)
+        }
+    }
+}
+
+private extension Raster.Dash {
+    var controlGlyph: String {
+        switch self {
+        case .solid: "━━"
+        case .dashed: "━ ━"
+        case .dotted: "•••"
         }
     }
 }

--- a/App/UI/Tooltip.swift
+++ b/App/UI/Tooltip.swift
@@ -78,12 +78,27 @@ final class TooltipController {
     private(set) var shortcut: String?
     private(set) var detail: String?
 
+    /// The hovered control's frame in screen coordinates, for the controls whose
+    /// chip cannot be positioned from the rail's own geometry.
+    ///
+    /// The rail knows where its cells are, so it leaves this nil and offsets the
+    /// chip itself. The header does not — its cluster slides with the window
+    /// width — so header buttons report where they actually are and the chip
+    /// follows the glyph rather than guessing at the middle of the row.
+    private(set) var anchor: CGRect?
+
     @ObservationIgnored private var pendingKey: String?
     @ObservationIgnored private var work: DispatchWorkItem?
 
     var isVisible: Bool { visibleKey != nil }
 
-    func hover(key: String, title: String, shortcut: String?, detail: String? = nil) {
+    func hover(
+        key: String,
+        title: String,
+        shortcut: String?,
+        detail: String? = nil,
+        anchor: CGRect? = nil
+    ) {
         guard pendingKey != key else { return }
         pendingKey = key
         work?.cancel()
@@ -94,6 +109,7 @@ final class TooltipController {
             self.title = title
             self.shortcut = shortcut
             self.detail = detail
+            self.anchor = anchor
             return
         }
 
@@ -104,6 +120,7 @@ final class TooltipController {
                 self.title = title
                 self.shortcut = shortcut
                 self.detail = detail
+                self.anchor = anchor
             }
         }
         work = item
@@ -121,6 +138,7 @@ final class TooltipController {
             MainActor.assumeIsolated {
                 guard let self, self.pendingKey == nil else { return }
                 self.visibleKey = nil
+                self.anchor = nil
             }
         }
         work = item
@@ -131,5 +149,6 @@ final class TooltipController {
         work?.cancel()
         pendingKey = nil
         visibleKey = nil
+        anchor = nil
     }
 }

--- a/AppTests/EssentialsTests.swift
+++ b/AppTests/EssentialsTests.swift
@@ -20,10 +20,10 @@ struct EssentialsTests {
         model.shapeKind = .rectangle
         model.shapeStyle = .filled
         model.brushSize = 1
-        model.background = PaintColour(hex: "FF0000")!
+        model.foreground = PaintColour(hex: "FF0000")!
         _ = model.engine.beginStroke(at: PixelPoint(x: 19, y: 19))
         model.noteChange(model.engine.endStroke(at: PixelPoint(x: 61, y: 61)))
-        model.background = .white
+        model.foreground = .black
         return model
     }
 

--- a/AppTests/PDFDocumentTests.swift
+++ b/AppTests/PDFDocumentTests.swift
@@ -1,0 +1,232 @@
+import AppKit
+import CoreGraphics
+import CoreText
+import Foundation
+import PaintKit
+import Testing
+@testable import ItsPaint
+
+/// Signing a PDF, at the document layer.
+///
+/// PaintKit proves the codec keeps every page; these prove the *document* does —
+/// that opening a contract fills the canvas, that the header is told which page
+/// it is on, that turning a page keeps what was drawn on the last one, and that
+/// Save writes a PDF rather than a picture of one.
+@Suite("PDF documents", .serialized)
+@MainActor
+struct PDFDocumentTests {
+
+    private func container() throws -> URL {
+        // Inside the app's own container: these tests run in the sandboxed app,
+        // and nowhere else is writable without a save panel.
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent("pdf-tests-\(UUID().uuidString)", isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        return directory
+    }
+
+    private func writeSample(pages: Int, to url: URL) throws {
+        let output = NSMutableData()
+        let consumer = try #require(CGDataConsumer(data: output))
+        var box = CGRect(x: 0, y: 0, width: 612, height: 792)
+        let context = try #require(CGContext(consumer: consumer, mediaBox: &box, nil))
+        for page in 1...pages {
+            context.beginPDFPage(nil)
+            let font = CTFontCreateWithName("Helvetica" as CFString, 32, nil)
+            let line = CTLineCreateWithAttributedString(NSAttributedString(
+                string: "Agreement — page \(page)",
+                attributes: [kCTFontAttributeName as NSAttributedString.Key: font]
+            ))
+            context.textPosition = CGPoint(x: 64, y: 680)
+            CTLineDraw(line, context)
+            context.endPDFPage()
+        }
+        context.closePDF()
+        try (output as Data).write(to: url)
+    }
+
+    private func pageCount(of url: URL) throws -> Int {
+        let document = try #require(CGPDFDocument(url as CFURL))
+        return document.numberOfPages
+    }
+
+    @Test("Opening a PDF fills the canvas and names the page")
+    func opensAPage() throws {
+        let directory = try container()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("agreement.pdf")
+        try writeSample(pages: 3, to: url)
+
+        let document = DrawingDocument()
+        try document.read(from: url, ofType: "com.adobe.pdf")
+
+        #expect(document.model.canvasSize.width == 1224)
+        #expect(document.model.canvasSize.height == 1584)
+        let page = try #require(document.model.pdfPage)
+        #expect(page.index == 0)
+        #expect(page.count == 3)
+    }
+
+    @Test("Saving a signed page writes a PDF that still has every page")
+    func savesEveryPage() throws {
+        let directory = try container()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("lease.pdf")
+        try writeSample(pages: 4, to: url)
+
+        let document = DrawingDocument()
+        try document.read(from: url, ofType: "com.adobe.pdf")
+
+        // Sign it: a stroke, through the engine, exactly as the brush would.
+        document.model.selectTool(.brush)
+        document.model.brushSize = 12
+        document.model.foreground = .black
+        document.model.noteChange(document.model.engine.beginStroke(at: PixelPoint(x: 200, y: 1400)))
+        document.model.noteChange(document.model.engine.endStroke(at: PixelPoint(x: 600, y: 1420)))
+
+        let saved = directory.appendingPathComponent("lease-signed.pdf")
+        try document.write(to: saved, ofType: "com.adobe.pdf")
+
+        #expect(try pageCount(of: saved) == 4)
+
+        // And it reopens as a PDF, on a page the same size as the original.
+        let reopened = DrawingDocument()
+        try reopened.read(from: saved, ofType: "com.adobe.pdf")
+        #expect(reopened.model.canvasSize.width == 1224)
+        #expect(reopened.model.canvasSize.height == 1584)
+    }
+
+    @Test("Exporting at 200% sharpens the page, it does not double its size")
+    func exportScaleDoesNotResizeThePage() throws {
+        let directory = try container()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("invoice.pdf")
+        try writeSample(pages: 2, to: url)
+
+        let document = DrawingDocument()
+        try document.read(from: url, ofType: "com.adobe.pdf")
+
+        let options = ExportOptions()
+        options.format = .pdf
+        options.scale = 2
+        let job = options.job(
+            canvas: document.model.canvas,
+            matte: .white,
+            pdfSource: document.pdfSourceForTesting
+        )
+        let exported = directory.appendingPathComponent("invoice-2x.pdf")
+        try job.write(to: exported)
+
+        let written = try #require(CGPDFDocument(exported as CFURL))
+        #expect(written.numberOfPages == 2)
+        let page = try #require(written.page(at: 1))
+        #expect(page.getBoxRect(.mediaBox).size == CGSize(width: 612, height: 792))
+    }
+
+    @Test("Saving over the original keeps the document intact")
+    func savingInPlaceIsSafe() throws {
+        let directory = try container()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("terms.pdf")
+        try writeSample(pages: 3, to: url)
+
+        let document = DrawingDocument()
+        try document.read(from: url, ofType: "com.adobe.pdf")
+        var canvas = document.model.canvas
+        Raster.fillRect(
+            PixelRect(x: 100, y: 1200, width: 300, height: 60), colour: .black, into: &canvas
+        )
+        document.model.engine.reset(to: canvas)
+
+        try document.write(to: url, ofType: "com.adobe.pdf")
+
+        #expect(try pageCount(of: url) == 3)
+        #expect(
+            try FileManager.default.contentsOfDirectory(atPath: directory.path) == ["terms.pdf"],
+            "saving left a staging file in the document's own folder"
+        )
+
+        let reopened = DrawingDocument()
+        try reopened.read(from: url, ofType: "com.adobe.pdf")
+        let signed = try #require(
+            reopened.model.canvas.pixel(at: PixelPoint(x: 200, y: 1230))
+        )
+        #expect(signed.r < 60, "the mark did not survive saving over the original")
+    }
+
+    @Test("Turning the page keeps what was drawn on the page before it")
+    func pageTurnKeepsInk() throws {
+        let directory = try container()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("contract.pdf")
+        try writeSample(pages: 3, to: url)
+
+        let document = DrawingDocument()
+        try document.read(from: url, ofType: "com.adobe.pdf")
+
+        // A solid mark low on page one, well clear of the printed line.
+        let mark = PixelRect(x: 120, y: 1300, width: 360, height: 90)
+        var canvas = document.model.canvas
+        Raster.fillRect(mark, colour: .black, into: &canvas)
+        document.model.engine.reset(to: canvas)
+
+        document.model.turnToPage(1)
+        #expect(try #require(document.model.pdfPage).index == 1)
+        let onPageTwo = try #require(
+            document.model.canvas.pixel(at: PixelPoint(x: 300, y: 1340))
+        )
+        #expect(onPageTwo.r > 200, "page two came up carrying page one's ink")
+
+        document.model.turnToPage(0)
+        #expect(try #require(document.model.pdfPage).index == 0)
+        let backOnPageOne = try #require(
+            document.model.canvas.pixel(at: PixelPoint(x: 300, y: 1340))
+        )
+        #expect(backOnPageOne.r < 60, "the mark on page one was lost by turning the page")
+    }
+
+    /// The window, with a contract open in it, rendered to a PNG.
+    ///
+    /// Same harness as the README captures: set `ITSPAINT_PDF_CAPTURE_OUT` and it
+    /// writes the window; unset, it is a plain document test that costs CI
+    /// nothing.
+    @Test("Captures the window with a PDF open when asked")
+    func capturesTheWindow() throws {
+        let directory = try container()
+        defer { try? FileManager.default.removeItem(at: directory) }
+        let url = directory.appendingPathComponent("Rental agreement.pdf")
+        try writeSample(pages: 5, to: url)
+
+        let document = DrawingDocument()
+        try document.read(from: url, ofType: "com.adobe.pdf")
+        document.fileURL = url
+        document.makeWindowControllers()
+        document.showWindows()
+
+        let window = try #require(document.windowControllers.first?.window)
+        window.makeKeyAndOrderFront(nil)
+        #expect(document.model.pdfPage?.count == 5)
+
+        guard let out = ProcessInfo.processInfo.environment["ITSPAINT_PDF_CAPTURE_OUT"] else {
+            document.close()
+            return
+        }
+
+        var patience = 100
+        while !NSApp.isActive && patience > 0 {
+            NSApp.activate(ignoringOtherApps: true)
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+            patience -= 1
+        }
+        for _ in 0..<20 {
+            RunLoop.main.run(until: Date(timeIntervalSinceNow: 0.05))
+        }
+
+        let themeFrame = try #require(window.contentView?.superview)
+        let rep = try #require(themeFrame.bitmapImageRepForCachingDisplay(in: themeFrame.bounds))
+        themeFrame.cacheDisplay(in: themeFrame.bounds, to: rep)
+        let png = try #require(rep.representation(using: .png, properties: [:]))
+        try png.write(to: URL(fileURLWithPath: out))
+        document.close()
+    }
+}

--- a/AppTests/TooltipRenderTests.swift
+++ b/AppTests/TooltipRenderTests.swift
@@ -54,4 +54,64 @@ struct TooltipRenderTests {
                     "\(tool)'s tip opens by repeating its own name")
         }
     }
+
+    /// The header's chip is positioned by hand, because its buttons sit in a
+    /// capsule that clips anything drawn inside it. Whatever the arithmetic does,
+    /// it must never leave the chip hanging off the window.
+    @Test("The header chip stays inside the window at either end of the row")
+    func headerChipIsClamped() {
+        let window = CGRect(x: 0, y: 0, width: 900, height: 600)
+        let chip = CGFloat(220)
+
+        // Under a button in the middle: centred on the button.
+        let middle = CGRect(x: 440, y: 8, width: 26, height: 26)
+        #expect(
+            EditorView.tooltipCentre(under: middle, in: window, chipWidth: chip) == middle.midX
+        )
+
+        // Under the last button before the right edge: pulled back inside.
+        let trailing = CGRect(x: 870, y: 8, width: 26, height: 26)
+        let clamped = EditorView.tooltipCentre(under: trailing, in: window, chipWidth: chip)
+        #expect(clamped + chip / 2 <= window.width)
+        #expect(clamped < trailing.midX)
+
+        // And at the leading edge, the same in reverse.
+        let leading = CGRect(x: 2, y: 8, width: 26, height: 26)
+        let pushed = EditorView.tooltipCentre(under: leading, in: window, chipWidth: chip)
+        #expect(pushed - chip / 2 >= 0)
+        #expect(pushed > leading.midX)
+
+        // A window narrower than the chip cannot contain it; centre it rather
+        // than pinning it to one side and cutting the whole sentence off.
+        let narrow = CGRect(x: 0, y: 0, width: 120, height: 600)
+        #expect(
+            EditorView.tooltipCentre(under: leading, in: narrow, chipWidth: chip) == 60
+        )
+    }
+
+    /// The header's own chips carry a line of explanation, and the buttons they
+    /// belong to are the ones people reported not recognising. They get the same
+    /// size check the tools' tips get.
+    @Test("Header chips read in one or two lines")
+    func headerChipsAreReadable() throws {
+        let chips: [(String, String)] = [
+            ("Copy image", "Puts it on the clipboard, ready to paste anywhere"),
+            ("Paste image", "Drops the clipboard onto the canvas, still movable"),
+            ("Drag image out", "Pick the picture up and drop it into Slack, Mail or the Finder"),
+            ("Signature", "Sign here, or drop in a signature you have already saved"),
+            ("Duplicate", "Opens a copy in a new window"),
+        ]
+
+        for (title, detail) in chips {
+            let view = Tooltip(title: title, shortcut: "⌘C", detail: detail)
+                .padding(10)
+                .environment(\.colorScheme, .dark)
+                .background(Color(white: 0.13))
+            let renderer = ImageRenderer(content: view)
+            renderer.scale = 2
+            let image = try #require(renderer.nsImage, "\(title) chip did not render")
+            #expect(image.size.width <= 260, "\(title) chip is \(image.size.width)pt wide")
+            #expect(image.size.height <= 66, "\(title) chip wrapped to \(image.size.height)pt")
+        }
+    }
 }

--- a/AppTests/WindowCaptureTests.swift
+++ b/AppTests/WindowCaptureTests.swift
@@ -63,6 +63,11 @@ struct WindowCaptureTests {
         if let grid = environment["ITSPAINT_CAPTURE_SNAP"], let spacing = Int(grid) {
             document.model.snapGrid = spacing
         }
+        // The bottom rail lays its options panel out along the other axis, so a
+        // control that only misbehaves down there needs a capture down there.
+        if environment["ITSPAINT_CAPTURE_EDGE"] == "bottom" {
+            document.model.chromeEdge = .bottom
+        }
         if environment["ITSPAINT_CAPTURE_SELECTION"] != nil {
             // Make the marquee with the select tool, then restore whichever tool
             // the capture asked for — otherwise this quietly overwrites it and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ Notable changes, newest first. This project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Until 1.0 the minor
 version may still carry breaking changes to the document format.
 
-## [0.17.0] — 2026-08-21
+## [0.17.0] — 2026-08-22
 
 ### Added
 - **A PDF opens as a page, and saves as a PDF.** ImageIO can write a PDF and

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,69 @@ Notable changes, newest first. This project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Until 1.0 the minor
 version may still carry breaking changes to the document format.
 
+## [0.17.0] — 2026-08-21
+
+### Added
+- **A PDF opens as a page, and saves as a PDF.** ImageIO can write a PDF and
+  cannot read one, so opening a contract failed with *isn't an image ItsPaint can
+  read* — which made the signature tool a way to sign screenshots and nothing
+  else. Pages now come through Core Graphics' own PDF reader, rasterised at 144
+  dpi for editing, and saving writes the edited page back into the document it
+  came from: the page keeps the size it was printed at rather than becoming its
+  pixel count in points, and every page nobody touched is copied through with its
+  text still selectable.
+- **A page control, for documents that have pages.** It sits at the bottom of the
+  window with the paste bar, and only for PDFs. Turning a page folds the current
+  page back into the file first, so a signature on page four survives a look at
+  page five; the undo stack does not cross the boundary, because a replayed edit
+  belongs to the page it was made on.
+- **Signing has a button.** It lived only in Tools ▸ Signature… under ⌃⌘S, a
+  chord nothing else in the app uses — the one feature nobody would guess was the
+  one feature the window never mentioned. It is now in the header beside Share,
+  where the things you do to a finished document already are.
+- **ItsPaint appears under Open With for PDFs**, at `Alternate` rank. Opening a
+  page to draw on it is not the same job as reading a document, and Preview should
+  stay the Mac's PDF reader.
+
+### Changed
+- **A shape with no outline is filled with the colour you picked.** Fill used
+  Colour 2, which is the right answer for the inside of an outlined shape and the
+  wrong one when there is no outline to pair it with: choosing Fill on a fresh
+  document painted white on white paper, so the shape was invisible and the
+  colour in your hand did nothing. Outline still uses Colour 1, Outline and fill
+  still uses Colour 1 for the edge and Colour 2 for the inside, and right-dragging
+  still swaps the pair.
+
+### Fixed
+- **The size slider was unusable with the toolbar along the bottom.** The row
+  measures its own width down there, and a `GeometryReader` offers 10pt
+  intrinsically — so the slider was a stub you could not drag, while the same
+  control in the side rail was full width.
+- **The dashed and dotted line options showed a diagonal line.** Three glyphs
+  that all read as "a line" for three different stroke patterns; each segment now
+  shows the pattern it draws.
+- **Export could fail to write the file at all.** The encoder built its output in
+  a temporary file *beside* the destination, and a sandboxed app is granted the
+  path the save panel returned, not its folder — so the staged path was one the
+  app had no right to create. Core Graphics reported that as a destination it
+  could not make, and the alert read *Couldn't write the image as PDF*, followed
+  by advice to try PNG, which took the same denied route. The staging file now
+  lives in the app's own container and the finished bytes are moved onto the
+  granted path, with an in-place write as the fallback where even that is
+  refused. Present since 0.12.0, when writing moved off the in-memory route.
+- **Copy no longer goes dim when nothing is selected.** With a selection it
+  copies the selection; without one it copies the image, which is what ⌘C does in
+  every viewer people arrive from. A greyed-out Copy said "copying is
+  unavailable" while the obvious thing to copy was on screen.
+- **Duplicate asks first.** Two overlapping pages beside Share put a second
+  untitled window on screen with no warning, which is indistinguishable from
+  having lost your place in the one you were working in. The menu item still goes
+  straight through, because it says the word.
+- **The header's tooltips are the app's own chip.** The system's takes about a
+  second and shows no shortcut, which is why the paste clipboard and the drag-out
+  handle were reported as unidentifiable glyphs. They now name themselves in
+  300ms, with a line of explanation, exactly as the tool rail already did.
+
 ## [0.16.4] — 2026-08-21
 
 ### Changed

--- a/ItsPaint.xcodeproj/project.pbxproj
+++ b/ItsPaint.xcodeproj/project.pbxproj
@@ -34,6 +34,7 @@
 		71B8FC7E198B4F762F94C6A2 /* DocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F4A9F5632360B181403BDA /* DocumentTests.swift */; };
 		736B873DA05CA677039DB143 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 81D5AB95221C3E1A9DD3CFC7 /* Assets.xcassets */; };
 		762CD1BC00FE680EB32BD80B /* ColourPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83A429AB8B62EFEDC176D65 /* ColourPopover.swift */; };
+		7D7E217925BBD597F47772AE /* PDFDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D072F2FA0424641934102963 /* PDFDocumentTests.swift */; };
 		8CFB1C6C1779CAF721DD34EA /* FixedGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80562B1588560C2E61CCE65 /* FixedGrid.swift */; };
 		8DE72B90DE9FDDBCEA63C2FD /* ClipboardHotKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951512EED8AAC0B1B7716D54 /* ClipboardHotKey.swift */; };
 		924C2B7A35DD5F3985A29406 /* EssentialsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E4A12B57303E5FE405DFC /* EssentialsTests.swift */; };
@@ -97,6 +98,7 @@
 		C06E4A12B57303E5FE405DFC /* EssentialsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EssentialsTests.swift; sourceTree = "<group>"; };
 		C83A429AB8B62EFEDC176D65 /* ColourPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColourPopover.swift; sourceTree = "<group>"; };
 		CA3B7CF910C5BF4084044565 /* PaintKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PaintKit; path = Packages/PaintKit; sourceTree = SOURCE_ROOT; };
+		D072F2FA0424641934102963 /* PDFDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFDocumentTests.swift; sourceTree = "<group>"; };
 		E80562B1588560C2E61CCE65 /* FixedGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedGrid.swift; sourceTree = "<group>"; };
 		EA6F6F30090979763C866F84 /* SignatureSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureSheet.swift; sourceTree = "<group>"; };
 		F2ACA876E800C1AB89C90365 /* SizeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeSheet.swift; sourceTree = "<group>"; };
@@ -177,6 +179,7 @@
 				54F4A9F5632360B181403BDA /* DocumentTests.swift */,
 				C06E4A12B57303E5FE405DFC /* EssentialsTests.swift */,
 				B063B5E24D6EBB4CEB198E5B /* PasteGrowthTests.swift */,
+				D072F2FA0424641934102963 /* PDFDocumentTests.swift */,
 				073EFE49D21C2976F9D72BB4 /* ScreenshotWatcherTests.swift */,
 				605B317CA16CD2D068DF970B /* TextEditorLayoutTests.swift */,
 				F2C78F7D1A8AE0254D405787 /* ToolbarGeometryTests.swift */,
@@ -384,6 +387,7 @@
 				397D8480B03F1D4E483412F6 /* CanvasRenderingTests.swift in Sources */,
 				71B8FC7E198B4F762F94C6A2 /* DocumentTests.swift in Sources */,
 				924C2B7A35DD5F3985A29406 /* EssentialsTests.swift in Sources */,
+				7D7E217925BBD597F47772AE /* PDFDocumentTests.swift in Sources */,
 				1DE130CDBF4B6616B66BF5F1 /* PasteGrowthTests.swift in Sources */,
 				F0389C97B6274DF2552FE2B9 /* ScreenshotWatcherTests.swift in Sources */,
 				F4C7E8CF3B5107D648F3FC45 /* TextEditorLayoutTests.swift in Sources */,
@@ -443,7 +447,7 @@
 				CODE_SIGN_IDENTITY = "-";
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = dwarf;
 				DEVELOPMENT_TEAM = "";
@@ -465,7 +469,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.16.4;
+				MARKETING_VERSION = 0.17.0;
 				MTL_ENABLE_DEBUG_INFO = INCLUDE_SOURCE;
 				MTL_FAST_MATH = YES;
 				ONLY_ACTIVE_ARCH = YES;
@@ -534,7 +538,7 @@
 				CODE_SIGN_INJECT_BASE_ENTITLEMENTS = NO;
 				CODE_SIGN_STYLE = Manual;
 				COPY_PHASE_STRIP = NO;
-				CURRENT_PROJECT_VERSION = 14;
+				CURRENT_PROJECT_VERSION = 15;
 				DEAD_CODE_STRIPPING = YES;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				DEVELOPMENT_TEAM = "";
@@ -550,7 +554,7 @@
 				GCC_WARN_UNUSED_FUNCTION = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
 				MACOSX_DEPLOYMENT_TARGET = 14.0;
-				MARKETING_VERSION = 0.16.4;
+				MARKETING_VERSION = 0.17.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				MTL_FAST_MATH = YES;
 				PRODUCT_NAME = "$(TARGET_NAME)";

--- a/Packages/PaintKit/Sources/PaintDemo/ChameleonScene.swift
+++ b/Packages/PaintKit/Sources/PaintDemo/ChameleonScene.swift
@@ -467,7 +467,7 @@ enum ChameleonScene {
         let engine = canvas.engine
         engine.settings.brushSize = 1
         engine.settings.shapeStyle = .filled
-        engine.colours.background = colour
+        engine.colours.foreground = colour
         engine.settings.tool = .shape
         engine.settings.shapeKind = .polygon
         for point in points {
@@ -486,7 +486,7 @@ enum ChameleonScene {
         let engine = canvas.engine
         engine.settings.brushSize = 1
         engine.settings.shapeStyle = .filled
-        engine.colours.background = colour
+        engine.colours.foreground = colour
         canvas.shape(
             .ellipse,
             from: point(centre.x - radius, centre.y - radius),

--- a/Packages/PaintKit/Sources/PaintDemo/Icon.swift
+++ b/Packages/PaintKit/Sources/PaintDemo/Icon.swift
@@ -28,7 +28,7 @@ enum IconGenerator {
         engine.settings.shapeStyle = .filled
         engine.settings.brushSize = 1
         engine.settings.cornerRadius = Int(Double(size) * 0.205)
-        engine.colours.background = colour("FDFDFE")
+        engine.colours.foreground = colour("FDFDFE")
         engine.beginStroke(at: PixelPoint(x: body.minX - 1, y: body.minY - 1))
         engine.endStroke(at: PixelPoint(x: body.maxX, y: body.maxY))
 

--- a/Packages/PaintKit/Sources/PaintDemo/TransparencyScene.swift
+++ b/Packages/PaintKit/Sources/PaintDemo/TransparencyScene.swift
@@ -63,7 +63,7 @@ enum TransparencyScene {
         let engine = canvas.engine
         engine.settings.brushSize = 1
         engine.settings.shapeStyle = .filled
-        engine.colours.background = colour
+        engine.colours.foreground = colour
         polygon(on: canvas, points: points)
     }
 

--- a/Packages/PaintKit/Sources/PaintKit/Codec/FileStaging.swift
+++ b/Packages/PaintKit/Sources/PaintKit/Codec/FileStaging.swift
@@ -1,0 +1,84 @@
+import Foundation
+
+/// Build a file somewhere safe, then put it where it was asked for.
+///
+/// **The staging copy lives in this app's own temporary directory and never
+/// beside the destination.** A sandboxed app is granted the *path the user
+/// chose in the save panel* — not its folder — so a sibling
+/// `.itspaint-<uuid>.pdf` next to the chosen file is a new path nobody granted.
+/// Core Graphics reported that as a destination it could not create, the export
+/// surfaced *Couldn't write the image as PDF*, and the recovery text sent people
+/// to PNG, which took the same denied route. The format was never the problem.
+///
+/// Staging still buys what it was added for: the bytes land under their final
+/// name only once the encoder has finished, so a failure half-way through cannot
+/// leave someone with a truncated version of their artwork.
+enum FileStaging {
+
+    /// Run `body` against a staging URL, then move the result onto `url`.
+    ///
+    /// The staging file keeps the destination's last path component, so an
+    /// encoder that reads the extension sees the one the user typed.
+    static func replaceItem(at url: URL, writing body: (URL) throws -> Void) throws {
+        let manager = FileManager.default
+        let staging = manager.temporaryDirectory
+            .appendingPathComponent("itspaint-write-\(UUID().uuidString)", isDirectory: true)
+
+        do {
+            try manager.createDirectory(at: staging, withIntermediateDirectories: true)
+        } catch {
+            // No staging area at all — a full or read-only container. The
+            // destination is the only place left, and refusing to save at that
+            // point would lose the work outright.
+            try body(url)
+            return
+        }
+        defer { try? manager.removeItem(at: staging) }
+
+        let temporary = staging.appendingPathComponent(url.lastPathComponent)
+        try body(temporary)
+
+        do {
+            if manager.fileExists(atPath: url.path) {
+                _ = try manager.replaceItemAt(url, withItemAt: temporary)
+            } else {
+                try manager.moveItem(at: temporary, to: url)
+            }
+        } catch {
+            // Moving into place is a directory operation, and the grant may
+            // cover only the file itself; the same is true across volumes, where
+            // a rename cannot work at all. Writing the finished bytes *into* the
+            // granted path is the route that is left, and by this point they are
+            // complete — the encoder has already succeeded.
+            try copy(from: temporary, onto: url)
+        }
+    }
+
+    /// Stream a finished file onto an existing path, in place.
+    ///
+    /// **Nothing is deleted first.** The obvious version — remove the
+    /// destination, then copy — spends a moment where the user's artwork exists
+    /// nowhere but a temporary directory, and if the copy then fails they have
+    /// lost the file they were saving over. Truncating and writing keeps the
+    /// path, and a chunked copy keeps a 100 MB export from being held in memory
+    /// twice on the way through.
+    static func copy(from source: URL, onto destination: URL) throws {
+        let manager = FileManager.default
+        if !manager.fileExists(atPath: destination.path) {
+            guard manager.createFile(atPath: destination.path, contents: nil) else {
+                throw CocoaError(.fileWriteUnknown)
+            }
+        }
+
+        let reading = try FileHandle(forReadingFrom: source)
+        defer { try? reading.close() }
+        let writing = try FileHandle(forWritingTo: destination)
+        defer { try? writing.close() }
+        try writing.truncate(atOffset: 0)
+
+        while let chunk = try reading.read(upToCount: 1 << 20), !chunk.isEmpty {
+            try writing.write(contentsOf: chunk)
+        }
+        try writing.synchronize()
+    }
+}

--- a/Packages/PaintKit/Sources/PaintKit/Codec/ImageCodec.swift
+++ b/Packages/PaintKit/Sources/PaintKit/Codec/ImageCodec.swift
@@ -95,10 +95,15 @@ public enum ImageCodec {
         /// Whether this format only accepts a fixed set of square sizes.
         public var requiresIconSize: Bool { self == .ico }
 
-        /// Whether this machine's ImageIO can actually write it. Checked
-        /// against the installed encoders rather than assumed, so the export
-        /// list never offers a format that will fail at the last step.
-        public var isWritable: Bool { Self.writableIdentifiers.contains(utType.identifier) }
+        /// Whether this machine can actually write it. Checked against the
+        /// installed encoders rather than assumed, so the export list never
+        /// offers a format that will fail at the last step.
+        ///
+        /// PDF is exempt: it is written by Core Graphics' own PDF context rather
+        /// than by an ImageIO encoder, so the encoder list has no say in it.
+        public var isWritable: Bool {
+            self == .pdf || Self.writableIdentifiers.contains(utType.identifier)
+        }
 
         private static let writableIdentifiers: Set<String> = Set(
             (CGImageDestinationCopyTypeIdentifiers() as? [String]) ?? []
@@ -159,6 +164,12 @@ public enum ImageCodec {
     // MARK: - Decoding
 
     public static func decode(contentsOf url: URL) throws -> Bitmap {
+        // PDF is paper, not an image ImageIO can read — a page comes back
+        // through `PDFCodec`, which is also the only route that knows what size
+        // the page was printed at.
+        if Format.inferred(from: url) == .pdf {
+            return try PDFCodec.open(contentsOf: url).bitmap
+        }
         guard let source = CGImageSourceCreateWithURL(
             url as CFURL,
             decodingOptions
@@ -272,6 +283,11 @@ public enum ImageCodec {
         quality: Double = 0.9,
         matte: PaintColour = .white
     ) throws -> Data {
+        // One place decides what a PDF is, and it is not ImageIO.
+        if format == .pdf {
+            return try PDFCodec.encode(bitmap, replacing: nil)
+        }
+
         let output = NSMutableData()
         guard let destination = CGImageDestinationCreateWithData(
             output as CFMutableData,
@@ -294,45 +310,38 @@ public enum ImageCodec {
     /// its own output to the file descriptor instead, so a save costs the canvas
     /// and nothing else.
     ///
-    /// Still atomic: the bytes land in a sibling temporary file that replaces
-    /// `url` only once the encoder has finished, so a failure halfway through
-    /// cannot leave the user with a truncated version of their artwork.
+    /// Still atomic: the bytes are built under a staging path and replace `url`
+    /// only once the encoder has finished, so a failure halfway through cannot
+    /// leave the user with a truncated version of their artwork. That staging
+    /// path is in this app's container and emphatically *not* beside `url` —
+    /// see `FileStaging`, which is where the export bug lived.
     public static func write(
         _ bitmap: Bitmap,
         to url: URL,
         as format: Format? = nil,
         quality: Double = 0.9,
-        matte: PaintColour = .white
+        matte: PaintColour = .white,
+        pdfSource: PDFCodec.Source? = nil
     ) throws {
         let resolved = format ?? Format.inferred(from: url) ?? .png
-        let fileManager = FileManager.default
-        let temporary = url.deletingLastPathComponent()
-            .appendingPathComponent(".itspaint-\(UUID().uuidString).\(resolved.fileExtension)")
 
-        guard let destination = CGImageDestinationCreateWithURL(
-            temporary as CFURL,
-            resolved.utType.identifier as CFString,
-            1,
-            nil
-        ) else {
-            throw CodecError.encodeFailed(resolved)
-        }
-        do {
-            try encode(bitmap, as: resolved, quality: quality, matte: matte, into: destination)
-        } catch {
-            try? fileManager.removeItem(at: temporary)
-            throw error
+        // PDF goes to `PDFCodec`, which writes a page rather than an image: the
+        // right size in points, and the document's other pages still in it.
+        if resolved == .pdf {
+            try PDFCodec.write(bitmap, to: url, replacing: pdfSource)
+            return
         }
 
-        do {
-            if fileManager.fileExists(atPath: url.path) {
-                _ = try fileManager.replaceItemAt(url, withItemAt: temporary)
-            } else {
-                try fileManager.moveItem(at: temporary, to: url)
+        try FileStaging.replaceItem(at: url) { staged in
+            guard let destination = CGImageDestinationCreateWithURL(
+                staged as CFURL,
+                resolved.utType.identifier as CFString,
+                1,
+                nil
+            ) else {
+                throw CodecError.encodeFailed(resolved)
             }
-        } catch {
-            try? fileManager.removeItem(at: temporary)
-            throw error
+            try encode(bitmap, as: resolved, quality: quality, matte: matte, into: destination)
         }
     }
 

--- a/Packages/PaintKit/Sources/PaintKit/Codec/PDFCodec.swift
+++ b/Packages/PaintKit/Sources/PaintKit/Codec/PDFCodec.swift
@@ -1,0 +1,331 @@
+import CoreGraphics
+import Foundation
+
+/// PDF, which this app treats as paper rather than as one more image format.
+///
+/// ImageIO can write a PDF and cannot read one. That asymmetry is what made
+/// "open the contract, sign it, save it" impossible: the open failed outright
+/// with *isn't an image ItsPaint can read*, and the write wrapped the canvas in
+/// a page whose size was the pixel count in points — a letter page rasterised
+/// for editing came back seventeen inches wide. Core Graphics' own PDF document
+/// and PDF context do both jobs properly, so the format lives here instead.
+///
+/// **Every page the reader did not touch is copied through as itself.** A
+/// signature on page four of a lease must not cost the other pages their text,
+/// and must not cost them their existence either.
+public enum PDFCodec {
+
+    /// What a document opened from a PDF has to remember in order to write
+    /// itself back as one.
+    ///
+    /// `data` is the whole file, and it is the *working* copy rather than the
+    /// one on disk: turning to another page folds the edited canvas back into it
+    /// first, so page four's signature survives a trip to page five.
+    public struct Source: Sendable, Equatable {
+        public let data: Data
+        /// Zero-based, because every other index in this codebase is.
+        public let pageIndex: Int
+        public let pageCount: Int
+        /// The edited page's size in points, in the orientation it is displayed
+        /// in — a page carrying `/Rotate 90` is stored here already landscape,
+        /// so writing never has to think about rotation again.
+        public let pageSize: CGSize
+        /// Pixels per point the page was rasterised at. Writing divides by it,
+        /// which is what keeps a signed page the size it was printed at.
+        public let renderScale: Double
+
+        public var hasMorePages: Bool { pageCount > 1 }
+
+        /// The same page, about to be written from a canvas that has been
+        /// resampled by `factor`.
+        ///
+        /// Exporting a signed page at 200% should produce a sharper page, not a
+        /// page twice the size — so the extra pixels are recorded as extra
+        /// resolution rather than as extra paper.
+        public func resampled(by factor: Double) -> Source {
+            guard factor > 0, factor != 1 else { return self }
+            return Source(
+                data: data,
+                pageIndex: pageIndex,
+                pageCount: pageCount,
+                pageSize: pageSize,
+                renderScale: renderScale * factor
+            )
+        }
+    }
+
+    public enum Failure: LocalizedError, Equatable {
+        case unreadable(String)
+        case locked(String)
+        case empty(String)
+        case pageTooLarge(String, width: Double, height: Double)
+        case renderFailed(String)
+        case encodeFailed
+
+        public var errorDescription: String? {
+            switch self {
+            case .unreadable(let name):
+                "Couldn't open \(name)."
+            case .locked(let name):
+                "\(name) is password-protected."
+            case .empty(let name):
+                "\(name) has no pages."
+            case .pageTooLarge(let name, let width, let height):
+                "A page of \(name) is \(Int(width)) × \(Int(height)) points, which is too large to open."
+            case .renderFailed(let name):
+                "Couldn't draw the pages of \(name)."
+            case .encodeFailed:
+                "Couldn't write the image as PDF."
+            }
+        }
+
+        public var recoverySuggestion: String? {
+            switch self {
+            case .unreadable:
+                "It may be damaged, or it may not be a PDF."
+            case .locked:
+                "Open it in Preview, enter the password, and save a copy without one."
+            case .empty:
+                "Open it in Preview to check that it still has pages."
+            case .pageTooLarge:
+                "Scale the page down in Preview first, or export it as PNG and open that."
+            case .renderFailed, .encodeFailed:
+                "Try exporting the page as PNG instead."
+            }
+        }
+    }
+
+    /// 144 dpi. Twice the PDF's own unit, which is the point where body text
+    /// stays legible on screen and a signature laid over it does not look
+    /// pasted, while a letter page is still under two megapixels.
+    public static let preferredScale: Double = 2
+
+    // MARK: - Reading
+
+    public static func open(
+        contentsOf url: URL, page pageIndex: Int = 0
+    ) throws -> (bitmap: Bitmap, source: Source) {
+        guard let data = try? Data(contentsOf: url, options: .mappedIfSafe) else {
+            throw Failure.unreadable(url.lastPathComponent)
+        }
+        return try open(data: Data(data), page: pageIndex, named: url.lastPathComponent)
+    }
+
+    /// Rasterise one page of `data` and hand back everything needed to put it
+    /// back where it came from.
+    ///
+    /// The page is drawn onto white rather than onto transparency. A PDF page
+    /// has no background of its own, and a signed contract whose paper is
+    /// transparent looks like a bug in every viewer that puts something dark
+    /// behind it.
+    public static func open(
+        data: Data, page pageIndex: Int = 0, named name: String
+    ) throws -> (bitmap: Bitmap, source: Source) {
+        guard let provider = CGDataProvider(data: data as CFData),
+              let document = CGPDFDocument(provider)
+        else { throw Failure.unreadable(name) }
+
+        // A locked document reports pages it will not draw, so the useful answer
+        // is the password rather than "no pages" — bank statements and signed
+        // contracts arrive encrypted often enough to be worth naming.
+        guard !document.isEncrypted || document.isUnlocked else {
+            throw Failure.locked(name)
+        }
+
+        let count = document.numberOfPages
+        guard count > 0 else { throw Failure.empty(name) }
+        // Clamped rather than refused: a stale page index in a reopened
+        // document should land you on the last page, not on an error.
+        let index = min(max(pageIndex, 0), count - 1)
+        guard let page = document.page(at: index + 1) else { throw Failure.empty(name) }
+
+        let size = displaySize(of: page)
+        guard size.width >= 1, size.height >= 1 else { throw Failure.empty(name) }
+        guard let scale = renderScale(for: size) else {
+            throw Failure.pageTooLarge(name, width: size.width, height: size.height)
+        }
+
+        let width = max(1, Int((size.width * scale).rounded()))
+        let height = max(1, Int((size.height * scale).rounded()))
+        guard let rendered = render(page, at: scale, size: CGSize(width: width, height: height)),
+              let bitmap = Bitmap(cgImage: rendered)
+        else { throw Failure.renderFailed(name) }
+
+        return (
+            bitmap,
+            Source(
+                data: data,
+                pageIndex: index,
+                pageCount: count,
+                pageSize: size,
+                renderScale: scale
+            )
+        )
+    }
+
+    /// How many pages `url` has, without rasterising any of them. The open panel
+    /// asks so it can offer a page to start on.
+    public static func pageCount(contentsOf url: URL) -> Int {
+        guard let document = CGPDFDocument(url as CFURL) else { return 0 }
+        return document.numberOfPages
+    }
+
+    /// The page's box after its own `/Rotate` entry is applied, which is the
+    /// shape the reader sees.
+    private static func displaySize(of page: CGPDFPage) -> CGSize {
+        let box = page.getBoxRect(.mediaBox)
+        let quarterTurns = ((page.rotationAngle % 360) + 360) % 360
+        return quarterTurns == 90 || quarterTurns == 270
+            ? CGSize(width: box.height, height: box.width)
+            : box.size
+    }
+
+    /// The largest scale at or below `preferredScale` that the canvas budget
+    /// allows, halving until it fits. `nil` when even 1:1 is too big — an
+    /// architectural drawing rather than a contract.
+    private static func renderScale(for size: CGSize) -> Double? {
+        var scale = preferredScale
+        while scale >= 0.125 {
+            let width = Int((size.width * scale).rounded())
+            let height = Int((size.height * scale).rounded())
+            if Bitmap.isSizeSupported(width: max(1, width), height: max(1, height)) {
+                return scale
+            }
+            scale /= 2
+        }
+        return nil
+    }
+
+    /// Draw a page into its own bitmap context.
+    ///
+    /// Not `Bitmap.drawWithCoreGraphics`: that flips the context so path and
+    /// text drawing can use canvas coordinates, and a PDF page drawn through
+    /// that flip lands upside down. Rendering into a context here and importing
+    /// the result through `Bitmap(cgImage:)` is the same route every other
+    /// imported image takes.
+    private static func render(_ page: CGPDFPage, at scale: Double, size: CGSize) -> CGImage? {
+        let width = Int(size.width), height = Int(size.height)
+        guard let context = CGContext(
+            data: nil,
+            width: width,
+            height: height,
+            bitsPerComponent: 8,
+            bytesPerRow: 0,
+            space: Bitmap.colourSpace,
+            bitmapInfo: Bitmap.bitmapInfo.rawValue
+        ) else { return nil }
+
+        context.setFillColor(gray: 1, alpha: 1)
+        context.fill(CGRect(x: 0, y: 0, width: width, height: height))
+        context.scaleBy(x: scale, y: scale)
+        // `getDrawingTransform` is what applies the page's own rotation and
+        // crop offset. Handing it the display-sized box means a rotated page
+        // arrives upright and a page whose media box does not start at the
+        // origin arrives in frame.
+        context.concatenate(
+            page.getDrawingTransform(
+                .mediaBox,
+                rect: CGRect(origin: .zero, size: displaySize(of: page)),
+                rotate: 0,
+                preserveAspectRatio: true
+            )
+        )
+        context.drawPDFPage(page)
+        return context.makeImage()
+    }
+
+    // MARK: - Writing
+
+    /// The canvas as a PDF: one page when it came from nowhere, and the original
+    /// document with one page replaced when it came from a PDF.
+    public static func encode(_ bitmap: Bitmap, replacing source: Source?) throws -> Data {
+        guard let image = bitmap.makeCGImage() else { throw Failure.encodeFailed }
+
+        let output = NSMutableData()
+        guard let consumer = CGDataConsumer(data: output) else { throw Failure.encodeFailed }
+
+        let edited = editedPageSize(for: bitmap, source: source)
+        var mediaBox = CGRect(origin: .zero, size: edited)
+        guard let context = CGContext(consumer: consumer, mediaBox: &mediaBox, nil) else {
+            throw Failure.encodeFailed
+        }
+
+        let original = source.flatMap { source -> CGPDFDocument? in
+            guard let provider = CGDataProvider(data: source.data as CFData) else { return nil }
+            return CGPDFDocument(provider)
+        }
+
+        if let original, let source, original.numberOfPages > 0 {
+            for number in 1...original.numberOfPages {
+                guard let page = original.page(at: number) else { continue }
+                let isEdited = number == source.pageIndex + 1
+                let size = isEdited ? edited : displaySize(of: page)
+                beginPage(context, size: size)
+                if isEdited {
+                    context.draw(image, in: CGRect(origin: .zero, size: size))
+                } else {
+                    // The untouched pages stay vector: drawing a PDF page into a
+                    // PDF context copies its content streams rather than
+                    // rasterising them, so page five is still selectable text
+                    // after page four has been signed.
+                    context.concatenate(
+                        page.getDrawingTransform(
+                            .mediaBox,
+                            rect: CGRect(origin: .zero, size: size),
+                            rotate: 0,
+                            preserveAspectRatio: true
+                        )
+                    )
+                    context.drawPDFPage(page)
+                }
+                context.endPDFPage()
+            }
+        } else {
+            beginPage(context, size: edited)
+            context.draw(image, in: CGRect(origin: .zero, size: edited))
+            context.endPDFPage()
+        }
+
+        context.closePDF()
+        guard output.length > 0 else { throw Failure.encodeFailed }
+        return output as Data
+    }
+
+    /// Write `bitmap` as a PDF at `url`, staged so a failure part-way cannot
+    /// leave a half-written document behind.
+    public static func write(_ bitmap: Bitmap, to url: URL, replacing source: Source?) throws {
+        let data = try encode(bitmap, replacing: source)
+        try FileStaging.replaceItem(at: url) { staged in
+            try data.write(to: staged)
+        }
+    }
+
+    /// The size of the page being written.
+    ///
+    /// Divided by the scale it was rasterised at, so a page opened at 144 dpi
+    /// and signed goes back out at its printed size. A canvas that never came
+    /// from a PDF keeps the one mapping every other tool uses for this — a pixel
+    /// is a point — because inventing a DPI for someone's screenshot would make
+    /// the page a surprise.
+    private static func editedPageSize(for bitmap: Bitmap, source: Source?) -> CGSize {
+        guard let source, source.renderScale > 0 else {
+            return CGSize(width: bitmap.width, height: bitmap.height)
+        }
+        // Cropping or resizing the canvas changes the page with it rather than
+        // stretching the artwork back over the old box.
+        return CGSize(
+            width: Double(bitmap.width) / source.renderScale,
+            height: Double(bitmap.height) / source.renderScale
+        )
+    }
+
+    private static func beginPage(_ context: CGContext, size: CGSize) {
+        var box = CGRect(origin: .zero, size: size)
+        let info = [
+            kCGPDFContextMediaBox as String: NSData(
+                bytes: &box, length: MemoryLayout<CGRect>.size
+            )
+        ]
+        context.beginPDFPage(info as CFDictionary)
+    }
+}

--- a/Packages/PaintKit/Sources/PaintKit/Tools/PaintEngine.swift
+++ b/Packages/PaintKit/Sources/PaintKit/Tools/PaintEngine.swift
@@ -1311,10 +1311,16 @@ public final class PaintEngine {
         guard let pending = pendingPolygon else { return .empty }
         canvas = pending.before
         let points = pending.points + (pending.points.last == preview ? [] : [preview])
+        let style = settings.shapeStyle
+        let stroke = colours.colour(for: button).rgba8
+        // The paired white is invisible on fresh white paper when no outline can reveal it.
+        let fill = (style.drawsOutline
+            ? colours.colour(for: button == .primary ? .secondary : .primary)
+            : colours.colour(for: button)).rgba8
         drawPolygonShape(
             points,
-            stroke: colours.colour(for: button).rgba8,
-            fill: colours.colour(for: button == .primary ? .secondary : .primary).rgba8,
+            stroke: stroke,
+            fill: fill,
             closed: points.count > 2
         )
         return canvas.bounds
@@ -1916,10 +1922,13 @@ public final class PaintEngine {
     // MARK: - Shapes
 
     private func drawShape(from origin: PixelPoint, to end: PixelPoint, button: PointerButton) -> PixelRect {
-        let stroke = colours.colour(for: button).rgba8
-        let fill = colours.colour(for: button == .primary ? .secondary : .primary).rgba8
-        let brush = activeBrush
         let style = settings.shapeStyle
+        let stroke = colours.colour(for: button).rgba8
+        // The paired white is invisible on fresh white paper when no outline can reveal it.
+        let fill = (style.drawsOutline
+            ? colours.colour(for: button == .primary ? .secondary : .primary)
+            : colours.colour(for: button)).rgba8
+        let brush = activeBrush
         var dirty = PixelRect.empty
 
         switch settings.shapeKind {

--- a/Packages/PaintKit/Tests/PaintKitTests/FloatingSelectionTests.swift
+++ b/Packages/PaintKit/Tests/PaintKitTests/FloatingSelectionTests.swift
@@ -141,10 +141,10 @@ struct SelectionInteractionTests {
         engine.settings.shapeKind = .rectangle
         engine.settings.shapeStyle = .filled
         engine.settings.brushSize = 1
-        engine.colours.background = PaintColour(hex: "FF0000")!
+        engine.colours.foreground = PaintColour(hex: "FF0000")!
         engine.beginStroke(at: PixelPoint(x: 19, y: 19))
         engine.endStroke(at: PixelPoint(x: 71, y: 71))
-        engine.colours.background = .white
+        engine.colours.foreground = .black
         return engine
     }
 

--- a/Packages/PaintKit/Tests/PaintKitTests/LassoCropTrimTests.swift
+++ b/Packages/PaintKit/Tests/PaintKitTests/LassoCropTrimTests.swift
@@ -12,10 +12,10 @@ struct LassoTests {
         engine.settings.shapeKind = .rectangle
         engine.settings.shapeStyle = .filled
         engine.settings.brushSize = 1
-        engine.colours.background = PaintColour(hex: "FF0000")!
+        engine.colours.foreground = PaintColour(hex: "FF0000")!
         engine.beginStroke(at: PixelPoint(x: 19, y: 19))
         engine.endStroke(at: PixelPoint(x: 80, y: 80))
-        engine.colours.background = .white
+        engine.colours.foreground = .black
         return engine
     }
 
@@ -154,10 +154,10 @@ struct CropTests {
         engine.settings.shapeKind = .rectangle
         engine.settings.shapeStyle = .filled
         engine.settings.brushSize = 1
-        engine.colours.background = PaintColour(hex: "FF0000")!
+        engine.colours.foreground = PaintColour(hex: "FF0000")!
         engine.beginStroke(at: PixelPoint(x: 19, y: 19))
         engine.endStroke(at: PixelPoint(x: 60, y: 60))
-        engine.colours.background = .white
+        engine.colours.foreground = .black
         return engine
     }
 
@@ -221,7 +221,7 @@ struct TrimTests {
         engine.settings.shapeKind = .rectangle
         engine.settings.shapeStyle = .filled
         engine.settings.brushSize = 1
-        engine.colours.background = PaintColour(hex: "3366CC")!
+        engine.colours.foreground = PaintColour(hex: "3366CC")!
         engine.beginStroke(at: PixelPoint(x: 19, y: 14))
         engine.endStroke(at: PixelPoint(x: 80, y: 65))
         return engine
@@ -249,7 +249,7 @@ struct TrimTests {
         engine.settings.shapeKind = .rectangle
         engine.settings.shapeStyle = .filled
         engine.settings.brushSize = 1
-        engine.colours.background = .black
+        engine.colours.foreground = .black
         engine.beginStroke(at: PixelPoint(x: 19, y: 14))
         engine.endStroke(at: PixelPoint(x: 60, y: 45))
 

--- a/Packages/PaintKit/Tests/PaintKitTests/PDFCodecTests.swift
+++ b/Packages/PaintKit/Tests/PaintKitTests/PDFCodecTests.swift
@@ -1,0 +1,240 @@
+import CoreGraphics
+import CoreText
+import Foundation
+import Testing
+
+@testable import PaintKit
+
+/// Opening a PDF, signing a page, and getting the *document* back.
+///
+/// The feature these tests defend is the one thing a signature is for: the other
+/// pages of the contract still being there, and the page still being the size it
+/// was printed at.
+struct PDFCodecTests {
+
+    /// A PDF with `pages` letter pages, each carrying real text so a rasterised
+    /// page can be told apart from a blank one.
+    private func sampleDocument(pages: Int, size: CGSize = CGSize(width: 612, height: 792)) throws -> Data {
+        let output = NSMutableData()
+        let consumer = try #require(CGDataConsumer(data: output))
+        var box = CGRect(origin: .zero, size: size)
+        let context = try #require(CGContext(consumer: consumer, mediaBox: &box, nil))
+
+        for page in 1...pages {
+            context.beginPDFPage(nil)
+            let font = CTFontCreateWithName("Helvetica" as CFString, 36, nil)
+            let line = CTLineCreateWithAttributedString(NSAttributedString(
+                string: "Page \(page)",
+                attributes: [kCTFontAttributeName as NSAttributedString.Key: font]
+            ))
+            context.textPosition = CGPoint(x: 72, y: size.height - 120)
+            CTLineDraw(line, context)
+            context.endPDFPage()
+        }
+        context.closePDF()
+        return output as Data
+    }
+
+    private func pageCount(of data: Data) throws -> Int {
+        let provider = try #require(CGDataProvider(data: data as CFData))
+        let document = try #require(CGPDFDocument(provider))
+        return document.numberOfPages
+    }
+
+    private func pageSize(of data: Data, page: Int) throws -> CGSize {
+        let provider = try #require(CGDataProvider(data: data as CFData))
+        let document = try #require(CGPDFDocument(provider))
+        let page = try #require(document.page(at: page))
+        return page.getBoxRect(.mediaBox).size
+    }
+
+    @Test("A page opens as pixels, at twice its point size")
+    func opensAPage() throws {
+        let (bitmap, source) = try PDFCodec.open(
+            data: try sampleDocument(pages: 1), named: "contract.pdf"
+        )
+        #expect(source.pageCount == 1)
+        #expect(source.pageIndex == 0)
+        #expect(source.renderScale == PDFCodec.preferredScale)
+        #expect(source.pageSize == CGSize(width: 612, height: 792))
+        #expect(bitmap.width == 1224)
+        #expect(bitmap.height == 1584)
+    }
+
+    @Test("The page arrives on white paper, with its ink on it")
+    func rendersInkOnPaper() throws {
+        let (bitmap, _) = try PDFCodec.open(
+            data: try sampleDocument(pages: 1), named: "contract.pdf"
+        )
+        let corner = try #require(bitmap.pixel(at: PixelPoint(x: 4, y: 4)))
+        #expect(corner == RGBA8(r: 255, g: 255, b: 255, a: 255))
+
+        // Somewhere in the text band there has to be ink, or the page rendered
+        // blank and the signature would be laid over nothing.
+        var darkest = 255
+        for y in 130..<220 {
+            for x in 140..<600 {
+                if let pixel = bitmap.pixel(at: PixelPoint(x: x, y: y)) {
+                    darkest = min(darkest, Int(pixel.r))
+                }
+            }
+        }
+        #expect(darkest < 100, "no text found on the rasterised page")
+    }
+
+    @Test("Signing page two keeps all five pages and their size")
+    func writeBackKeepsEveryPage() throws {
+        let original = try sampleDocument(pages: 5)
+        var (bitmap, source) = try PDFCodec.open(data: original, page: 1, named: "lease.pdf")
+
+        // The signature: a black block where nobody's text is.
+        Raster.fillRect(
+            PixelRect(x: 100, y: bitmap.height - 300, width: 400, height: 80),
+            colour: .black, into: &bitmap
+        )
+
+        let signed = try PDFCodec.encode(bitmap, replacing: source)
+        #expect(try pageCount(of: signed) == 5)
+        for page in 1...5 {
+            #expect(try pageSize(of: signed, page: page) == CGSize(width: 612, height: 792))
+        }
+
+        // And the edited page really is the edited one: reopening it finds the
+        // block, while its neighbour is untouched paper there.
+        let reopened = try PDFCodec.open(data: signed, page: 1, named: "lease.pdf")
+        let inSignature = try #require(
+            reopened.bitmap.pixel(at: PixelPoint(x: 300, y: reopened.bitmap.height - 260))
+        )
+        #expect(inSignature.r < 60)
+
+        let neighbour = try PDFCodec.open(data: signed, page: 2, named: "lease.pdf")
+        let sameSpot = try #require(
+            neighbour.bitmap.pixel(at: PixelPoint(x: 300, y: neighbour.bitmap.height - 260))
+        )
+        #expect(sameSpot.r > 200)
+
+        source = reopened.source
+        #expect(source.pageIndex == 1)
+        #expect(source.pageCount == 5)
+    }
+
+    @Test("A cropped page comes back smaller, not stretched")
+    func croppingShrinksThePage() throws {
+        let (bitmap, source) = try PDFCodec.open(
+            data: try sampleDocument(pages: 1), named: "form.pdf"
+        )
+        let cropped = try #require(ImageTransform.cropped(
+            bitmap, to: PixelRect(x: 0, y: 0, width: bitmap.width, height: bitmap.height / 2)
+        ))
+        let written = try PDFCodec.encode(cropped, replacing: source)
+        #expect(try pageSize(of: written, page: 1) == CGSize(width: 612, height: 396))
+    }
+
+    @Test("A canvas that never came from a PDF is one page, a point per pixel")
+    func plainCanvasBecomesOnePage() throws {
+        let bitmap = Bitmap(width: 300, height: 200, fill: .white)
+        let data = try PDFCodec.encode(bitmap, replacing: nil)
+        #expect(try pageCount(of: data) == 1)
+        #expect(try pageSize(of: data, page: 1) == CGSize(width: 300, height: 200))
+    }
+
+    @Test("PDF is writable and exportable, whatever ImageIO thinks")
+    func pdfIsOffered() {
+        #expect(ImageCodec.Format.pdf.isWritable)
+        #expect(ImageCodec.Format.exportable.contains(.pdf))
+    }
+
+    @Test("Opening a PDF through the image codec goes to the PDF reader")
+    func imageCodecOpensPDFs() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let url = directory.appendingPathComponent("statement.pdf")
+        try sampleDocument(pages: 2).write(to: url)
+
+        let bitmap = try ImageCodec.decode(contentsOf: url)
+        #expect(bitmap.width == 1224)
+        #expect(bitmap.height == 1584)
+    }
+
+    @Test("Damaged bytes fail with something a person can act on")
+    func rejectsRubbish() {
+        #expect(throws: PDFCodec.Failure.unreadable("nonsense.pdf")) {
+            try PDFCodec.open(data: Data("not a pdf at all".utf8), named: "nonsense.pdf")
+        }
+    }
+
+    /// The export bug: a staged write must never create a second file in the
+    /// directory the save panel granted a single path in.
+    @Test("Writing a file leaves nothing else behind in the destination folder")
+    func writingCreatesNoSiblings() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let bitmap = Bitmap(width: 32, height: 32, fill: .white)
+        for format in ImageCodec.Format.exportable {
+            let url = directory.appendingPathComponent("art.\(format.fileExtension)")
+            try ImageCodec.write(bitmap, to: url, as: format)
+            #expect(FileManager.default.fileExists(atPath: url.path))
+
+            let contents = try FileManager.default.contentsOfDirectory(atPath: directory.path)
+            #expect(
+                contents == ["art.\(format.fileExtension)"],
+                "\(format.displayName) left \(contents) in the destination folder"
+            )
+            try FileManager.default.removeItem(at: url)
+        }
+    }
+
+    /// The route taken when the sandbox will not let the staged file be moved
+    /// into place: the destination is written *through*, never deleted first.
+    @Test("The in-place fallback replaces the bytes and keeps the same file")
+    func inPlaceFallbackKeepsTheFile() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let destination = directory.appendingPathComponent("art.png")
+        try Data(repeating: 0x41, count: 4096).write(to: destination)
+        let before = try FileManager.default.attributesOfItem(atPath: destination.path)
+
+        let staged = directory.appendingPathComponent("staged.png")
+        let fresh = Data(repeating: 0x42, count: 3 << 20)
+        try fresh.write(to: staged)
+
+        try FileStaging.copy(from: staged, onto: destination)
+
+        #expect(try Data(contentsOf: destination) == fresh, "the file was not fully replaced")
+        let after = try FileManager.default.attributesOfItem(atPath: destination.path)
+        #expect(
+            before[.systemFileNumber] as? Int == after[.systemFileNumber] as? Int,
+            "the destination was recreated rather than written through"
+        )
+
+        // And onto a path that does not exist yet, which is the ordinary export.
+        let new = directory.appendingPathComponent("new.png")
+        try FileStaging.copy(from: staged, onto: new)
+        #expect(try Data(contentsOf: new) == fresh)
+    }
+
+    @Test("Overwriting an existing file replaces it and stages nothing beside it")
+    func overwritingIsClean() throws {
+        let directory = FileManager.default.temporaryDirectory
+            .appendingPathComponent(UUID().uuidString, isDirectory: true)
+        try FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        defer { try? FileManager.default.removeItem(at: directory) }
+
+        let url = directory.appendingPathComponent("art.png")
+        try Data("stale".utf8).write(to: url)
+        try ImageCodec.write(Bitmap(width: 16, height: 16, fill: .black), to: url, as: .png)
+
+        #expect(try FileManager.default.contentsOfDirectory(atPath: directory.path) == ["art.png"])
+        let reopened = try ImageCodec.decode(contentsOf: url)
+        #expect(reopened.width == 16)
+    }
+}

--- a/Packages/PaintKit/Tests/PaintKitTests/PaintEngineTests.swift
+++ b/Packages/PaintKit/Tests/PaintKitTests/PaintEngineTests.swift
@@ -455,6 +455,20 @@ struct EngineGestureTests {
         #expect(engine.canvas.pixel(at: PixelPoint(x: 20, y: 20)) == PaintColour(hex: "FF0000")!.rgba8)
     }
 
+    @Test("A filled shape uses the colour loaded by the button")
+    func filledShapeUsesButtonColour() {
+        let engine = PaintEngine(width: 40, height: 40)
+        engine.settings.tool = .shape
+        engine.settings.shapeKind = .rectangle
+        engine.settings.shapeStyle = .filled
+        engine.settings.brushSize = 1
+        engine.colours = ColourPair(foreground: .black, background: .white)
+        engine.beginStroke(at: PixelPoint(x: 5, y: 5))
+        engine.endStroke(at: PixelPoint(x: 34, y: 34))
+
+        #expect(engine.canvas.pixel(at: PixelPoint(x: 20, y: 20)) == RGBA8.black)
+    }
+
     @Test("The eyedropper loads the sampled colour as foreground")
     func eyedropperSamples() {
         let engine = PaintEngine(width: 16, height: 16)
@@ -659,10 +673,10 @@ struct SelectionTests {
         engine.settings.shapeKind = .rectangle
         engine.settings.shapeStyle = .filled
         engine.settings.brushSize = 1
-        engine.colours.background = PaintColour(hex: "FF0000")!
+        engine.colours.foreground = PaintColour(hex: "FF0000")!
         engine.beginStroke(at: PixelPoint(x: 4, y: 4))
         engine.endStroke(at: PixelPoint(x: 21, y: 21))
-        engine.colours.background = .white
+        engine.colours.foreground = .black
         return engine
     }
 
@@ -1255,9 +1269,8 @@ struct MultiStepShapeTests {
 
         #expect(!engine.hasPendingShape)
         #expect(engine.undoStack.undoActionName == "Polygon")
-        // The interior is filled with the secondary colour, like every other
-        // closed shape.
-        #expect(engine.canvas.pixel(at: PixelPoint(x: 50, y: 40)) == PaintColour(hex: "FF0000")!.rgba8)
+        // With no outline, the loaded primary colour is the whole shape.
+        #expect(engine.canvas.pixel(at: PixelPoint(x: 50, y: 40)) == RGBA8.black)
     }
 
     @Test("A stray click or two leaves no polygon behind")

--- a/README.md
+++ b/README.md
@@ -119,7 +119,8 @@ issue and every comment, which is why most people do not.
 | **Drag straight out** | Into any app that takes an image. No save panel, and no `Screenshot 2026-08-07 at 11.42.13.png` left behind. |
 | **Paste onto anything** | It arrives floating. Bigger than the canvas and the canvas grows rather than cropping it. |
 | **Nine export formats** | PNG, JPEG, TIFF, BMP, GIF, HEIC, AVIF, PDF, ICO. Formats without alpha flatten onto Colour 2, not onto black. |
-| **Open With** | Registered for PNG, JPEG, TIFF, BMP, GIF and HEIC. |
+| **Sign a PDF** | Open a contract, sign the page, save it back as a PDF. The page stays the size it was printed at, and the pages you did not touch keep their text. |
+| **Open With** | Registered for PNG, JPEG, TIFF, BMP, GIF, HEIC and PDF. |
 
 ### Remove a background with no model and no network
 
@@ -297,8 +298,15 @@ corresponding encoder ships with the installed macOS version. The export panel h
 format and scale controls, and formats without alpha are flattened onto the second
 colour.
 
-ItsPaint registers as an editor for PNG, JPEG, TIFF, BMP, GIF and HEIC, so it appears
-under right-click ▸ **Open With**.
+A PDF opens as a page: ItsPaint rasterises the page you are working on at 144 dpi so
+you can draw on it, and keeps the file it came from. Saving writes a real PDF — the
+edited page at its original size in points, and every other page copied through with
+its text intact. Multi-page documents get a page control at the bottom of the window,
+and turning a page keeps what you drew on the last one.
+
+ItsPaint registers as an editor for PNG, JPEG, TIFF, BMP, GIF, HEIC and PDF, so it
+appears under right-click ▸ **Open With**. It asks for `Alternate` rank on PDF rather
+than owning the type, because Preview should stay the Mac's PDF reader.
 
 WebP export is not available, because macOS does not provide a WebP encoder. Text
 becomes pixels once it is committed.

--- a/docs/FEATURES.md
+++ b/docs/FEATURES.md
@@ -89,8 +89,17 @@ pixel art and nearest-neighbour scaling want. The pencil ignores the setting and
 always hard, because that is the promise of the pencil.
 
 **Every outline** can be solid, dashed or dotted, at any stroke weight; closed
-shapes can be outline, fill, or both. Fill uses Colour 2, outline uses Colour 1 —
-and right-dragging swaps that, like everywhere else.
+shapes can be outline, fill, or both.
+
+- **Outline** uses Colour 1.
+- **Outline and fill** uses Colour 1 for the edge and Colour 2 for the inside —
+  the pairing the two loaded colours exist for.
+- **Fill** uses Colour 1, because there is no edge to pair it with. It used to
+  use Colour 2, which meant choosing Fill on a fresh document drew a white
+  rectangle on white paper: the colour you had picked did nothing, and the shape
+  was invisible.
+
+Right-dragging swaps the pair, like everywhere else.
 
 Hold `⇧` while dragging to constrain: lines snap to 45°, boxes and ellipses to
 squares and circles.
@@ -168,10 +177,14 @@ selection (`⌘K`), trim borders (`⇧⌘T`).
 
 ## Signature
 
-`⌃⌘S` (`Tools ▸ Signature…`) opens the signing sheet. Sign in the box, or
-**Import Image…** a photo or scan of a signature on paper. Saved signatures
-appear as chips at the top of the sheet; clicking one inserts it, and
-right-clicking offers Delete.
+The signature button in the header — or `⌃⌘S`, or `Tools ▸ Signature…` — opens
+the signing sheet. Sign in the box, or **Import Image…** a photo or scan of a
+signature on paper. Saved signatures appear as chips at the top of the sheet;
+clicking one inserts it, and right-clicking offers Delete.
+
+The point of it is a PDF: open the contract, sign the page, save it back as a
+PDF. See **Files and export** below for what happens to the pages you did not
+touch.
 
 - **The ink is keyed to transparent**, so a signature lands on artwork without a
   white rectangle behind it. Alpha comes from how dark each pixel is relative to
@@ -207,12 +220,23 @@ only — an imported PNG is your file and is never re-encoded in the background.
 | PNG, TIFF, GIF | lossless, alpha preserved |
 | JPEG, BMP | no alpha — flattened onto Colour 2 first, rather than turning transparency black |
 | HEIC, AVIF | modern, lossy, quality slider |
-| PDF | the bitmap wrapped in a single-page PDF |
+| PDF | a page, not a picture — see below |
 | ICO | fitted and centred into the nearest legal icon square (16–256); a non-square ICO is not a large icon, it is an invalid file |
 
 The format list is filtered by what this machine's ImageIO can **actually
 encode**, so it never offers something that will fail at the last step. No WebP:
-macOS reads it but ships no encoder.
+macOS reads it but ships no encoder. PDF is the exception to that filter: Core
+Graphics' own PDF context writes it, not an ImageIO encoder.
+
+**PDF is paper.** Opening one rasterises the page at 144 dpi so it can be drawn
+on — a signature, a correction, a circle round the clause that matters — and
+keeps the file it came from. Saving writes the edited page back into that
+document at its original size in points, and copies every page nobody touched
+through as itself, text and all. Multi-page documents get a page control at the
+bottom of the window; turning a page folds the current one back into the file
+first, and clears the undo stack, because an undo belongs to the page it was made
+on. A canvas that never came from a PDF still exports as a single page, one point
+per pixel.
 
 ---
 

--- a/project.yml
+++ b/project.yml
@@ -32,8 +32,8 @@ settings:
   base:
     SWIFT_VERSION: "6.0"
     SWIFT_STRICT_CONCURRENCY: complete
-    MARKETING_VERSION: "0.16.4"
-    CURRENT_PROJECT_VERSION: "14"
+    MARKETING_VERSION: "0.17.0"
+    CURRENT_PROJECT_VERSION: "15"
     DEVELOPMENT_TEAM: ""
     # Ad-hoc signing. This is the correct choice for a locally built sandboxed
     # app: the sandbox and its entitlements work, and it needs no provisioning


### PR DESCRIPTION
## What this is

Signing only mattered on a PDF, and a PDF could not be opened: ImageIO writes them and cannot read them, so a contract dragged onto ItsPaint failed with *isn't an image ItsPaint can read*. Export could fail outright too, on any format.

## PDF

- `PDFCodec` reads a page with Core Graphics' own PDF reader (144 dpi), and writes the edited page back into the document it came from — original page size in points, every untouched page copied through with its text still selectable.
- Multi-page documents get a page control at the bottom of the window. Turning a page folds the current page back into the file first, and clears the undo stack, because a replayed bitmap edit belongs to the page it was made on.
- Password-protected documents say so instead of reporting "no pages".
- `com.adobe.pdf` is declared at `Alternate` rank: opening a page to draw on is not the same job as reading a document, and Preview stays the Mac's PDF reader.

## The export bug

`ImageCodec.write` staged its output in `.itspaint-<uuid>.<ext>` **beside** the destination. A sandboxed app is granted the path the save panel returned, not its folder, so that staging path was one it had no right to create — Core Graphics reported a destination it could not make and the alert read *Couldn't write the image as PDF*, then suggested PNG, which took the same denied route. Present since 0.12.0. Staging now happens in the app's container, with an in-place streamed write as the fallback where the move is refused (nothing is deleted before the replacement bytes exist).

## What the window was not saying

- Signing has a header button, beside Share.
- Header glyphs use the app's own tooltip chip: 300ms, with a line of explanation. The paste clipboard and the drag-out handle were reported as unidentifiable.
- Copy copies the whole image when nothing is selected instead of going dim.
- Duplicate asks before opening a second window; the menu item still goes straight through.
- A shape with no outline is filled with the colour you picked. Fill used Colour 2, so choosing it on a fresh document drew white on white.
- The size slider has real travel with the toolbar along the bottom, and each line-style segment shows the pattern it draws.

## Verification

- `swift test -c release --package-path Packages/PaintKit` — 338 tests pass, from a clean `.build`.
- `xcodebuild ... test` — 138 app tests pass, including a new "PDF documents" suite: opening a page, saving all five pages of a signed lease, saving over the original with nothing staged beside it, exporting at 200% without doubling the page, and a page turn that keeps the previous page's ink.
- Clean universal Release build (`ARCHS="arm64 x86_64"`) succeeds.
- Driven for real through the hosted window capture: a five-page PDF open in the app, page control at the bottom, signature button in the header; and the bottom-toolbar layout for the slider and line-style fixes.

Version bumped to 0.17.0 (build 15) in `project.yml` and the committed `.xcodeproj`.