### PR TITLE
Read every flag the archive script is given

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Preview markup has no step badges, no pixelate and no drag-out.
 
-**3.17 MB** · free on the App Store · MIT ·
+**3.28 MB** · free on the App Store · MIT ·
 **no network entitlement, so the kernel refuses a socket**
 
 [![Release](https://img.shields.io/github/v/release/joshlin2201/itspaint?sort=semver&style=flat-square&label=release&color=2563eb)](https://github.com/joshlin2201/itspaint/releases)
@@ -32,7 +32,7 @@ brew install --cask joshlin2201/itspaint/itspaint
 
 ## What makes it different
 
-- **3.17 MB, and a window on screen in half a second.** Krita is a gigabyte and
+- **3.28 MB, and a window on screen in half a second.** Krita is a gigabyte and
   built for painters. CleanShot X is $29 plus a cloud subscription. Preview is
   already on your Mac and will not number a step or pixelate a token.
 - **No network entitlement.** `com.apple.security.network.client` is not requested,
@@ -57,7 +57,7 @@ a PNG with none of the app around it. No AppKit, no third-party dependency, **ma
 and up**.
 
 ```swift
-.package(url: "https://github.com/joshlin2201/itspaint", from: "0.16.4")
+.package(url: "https://github.com/joshlin2201/itspaint", from: "0.17.0")
 ```
 
 [![Swift versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fjoshlin2201%2Fitspaint%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/joshlin2201/itspaint)
@@ -175,7 +175,7 @@ to hear about a new build.
 | **Requires** | macOS 14 Sonoma or later |
 | **Architecture** | universal, one build for Apple silicon and Intel |
 | **Signing** | Developer ID, notarised, ticket stapled to the image *and* the app, so the check needs no network and there is nothing to clear from the Terminal |
-| **Download** | 3.17 MB for the disk image, with a SHA-256 in `checksums.txt` |
+| **Download** | 3.28 MB for the disk image, with a SHA-256 in `checksums.txt` |
 
 ```bash
 shasum -a 256 -c checksums.txt

--- a/docs/APP_STORE.md
+++ b/docs/APP_STORE.md
@@ -225,7 +225,12 @@ is left is the part that is a legal declaration rather than an API call:
    a practical USPTO knock-out search, and that counsel-led clearance was named
    the gate for an App Store launch. That gate has not been closed.
 
-Release is set to **manual**, so an approval does not put a version on the
-store until it is released deliberately. Nothing in this app touches the usual
-Mac rejection reasons — no updater, no broad file access, no private API, no
-undeclared data collection.
+Release is **`AFTER_APPROVAL`**, so an approval puts the version on the store by
+itself. This document said "manual" until 0.17.0, when the API was actually
+read: `asc.py create_version` has always sent `releaseType: AFTER_APPROVAL`, and
+every shipped 0.16.x version carries it. Pass `MANUAL` there, or PATCH the
+version, if a release ever needs to be held behind an approval — and check the
+field rather than this sentence.
+
+Nothing in this app touches the usual Mac rejection reasons — no updater, no
+broad file access, no private API, no undeclared data collection.

--- a/scripts/appstore-archive.sh
+++ b/scripts/appstore-archive.sh
@@ -43,13 +43,25 @@ EXPORT=dist/appstore/export
 MODE=distribution
 UPLOAD=false
 EXTRA=(-allowProvisioningUpdates)
-case "${1:-}" in
-  --allow-provisioning) ;;
-  --upload) UPLOAD=true ;;
-  --validate-only) MODE=validate; EXTRA=() ;;
-  "") ;;
-  *) echo "Unknown option: $1" >&2; exit 2 ;;
-esac
+# Every argument, not just the first.
+#
+# This used to `case "${1:-}"`, so the documented-looking
+# `--allow-provisioning --upload` matched the first flag, dropped the second,
+# and exported a pkg while reporting "Re-run with --upload". A release step that
+# silently does less than it was asked is worse than one that refuses: the run
+# went green and nothing had been delivered.
+for arg in "$@"; do
+  case "$arg" in
+    --allow-provisioning) ;;
+    --upload) UPLOAD=true ;;
+    --validate-only) MODE=validate; EXTRA=() ;;
+    *) echo "Unknown option: $arg" >&2; exit 2 ;;
+  esac
+done
+if [[ "$MODE" == "validate" && "$UPLOAD" == "true" ]]; then
+  echo "--validate-only skips the distribution export, so there is nothing to upload." >&2
+  exit 2
+fi
 
 # CODE_SIGN_IDENTITY has to be overridden explicitly: project.yml pins it to "-"
 # for local builds, and that pin outranks CODE_SIGN_STYLE=Automatic, so without


### PR DESCRIPTION
`scripts/appstore-archive.sh` parsed `$1` only. `--allow-provisioning --upload` therefore matched `--allow-provisioning`, silently dropped `--upload`, exported the pkg and printed "Re-run with --upload" — the run went green having delivered nothing. Hit during the 0.17.0 App Store submission.

Now loops over `$@`, and refuses `--validate-only --upload` because validate-only skips the export the upload would send.

Checked by sourcing the parse block with each argument list: `--upload` and `--allow-provisioning --upload` both set UPLOAD=true, `--validate-only` clears the provisioning flag, no arguments keeps the default, `--nonsense` exits 2, and the contradictory pair refuses.