### PR TITLE
Say the test counts the suites now print

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ runs the whole engine suite:
 ```bash
 git clone https://github.com/joshlin2201/itspaint.git
 cd itspaint
-swift test          # 326 tests, 51 suites
+swift test          # 338 tests, 52 suites
 ```
 
 That is the entire loop for anything in `Packages/PaintKit/` — drawing, raster

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ with no UI framework and nothing third-party. The arrow never points the other
 way.
 
 This is what makes the whole tool matrix testable in milliseconds without
-launching an app — 326 engine tests cover it directly — and it means a UI
+launching an app — 338 engine tests cover it directly — and it means a UI
 redesign is a view-layer change rather than a rewrite. It has already survived
 one: the chrome was rebuilt from a floating cluster to a rail without the engine
 changing.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing protocol
 
-456 tests cover the engine and the Mac app. This document explains what each
+476 tests cover the engine and the Mac app. This document explains what each
 suite is for, how to write a test that will still be useful in a year, and the
 three failure modes that have already cost a day each.
 


### PR DESCRIPTION
`claims.py --refresh` measures 338 engine tests in 52 suites and 138 app tests after the 0.17.0 PDF work. Three files still said the old numbers:

- `CONTRIBUTING.md`: `# 326 tests, 51 suites` → 338 / 52
- `docs/ARCHITECTURE.md`: "326 engine tests cover it directly" → 338
- `docs/TESTING.md`: "456 tests cover the engine and the Mac app" → 476 (338 + 138)

The same run flags `docs/LAUNCH_KIT.md` in the private archive and the promo skill's own copy; those live outside this repository and were corrected there.