### PR TITLE
Put ItsPaint where macOS already offers to send an image

### DIFF
--- a/App/ItsPaintApp.swift
+++ b/App/ItsPaintApp.swift
@@ -57,6 +57,13 @@ final class ItsPaintAppDelegate: NSObject, NSApplicationDelegate {
         // is off until someone turns it on, and it stays off if the folder it was
         // given has since moved.
         _ = ScreenshotWatcher.shared
+
+        // The Info.plist entry puts "Edit in ItsPaint" in the Services menu; this
+        // is what makes choosing it do something. `NSUpdateDynamicServices` is
+        // for development — the system caches service definitions per app
+        // version, so without it a freshly built app shows yesterday's menu.
+        NSApp.servicesProvider = ImageService.shared
+        NSUpdateDynamicServices()
     }
 
     func applicationShouldOpenUntitledFile(_ sender: NSApplication) -> Bool { true }

--- a/App/Model/ClipboardHotKey.swift
+++ b/App/Model/ClipboardHotKey.swift
@@ -143,22 +143,9 @@ final class ClipboardHotKey {
         }
 
         do {
-            let bitmap = try Bitmap(pasteboard: board)
-            let controller = NSDocumentController.shared
-            guard let document = try controller.openUntitledDocumentAndDisplay(false)
-                    as? DrawingDocument
-            else {
-                present("That image could not be opened.", nil)
-                return
-            }
-            // `load` rather than `replaceCanvas`: this is the document's initial
-            // content, not an edit to it. Going through the undo-recording path
-            // would open a window already dirty, offering to save a file that
-            // never existed, with a stack whose bottom entry is a blank canvas
-            // nobody asked for.
-            document.model.load(canvas: bitmap, metadata: nil)
-            document.makeWindowControllers()
-            document.showWindows()
+            // Shared with the Services entry, which arrives the same way: an
+            // image from another app, no document to put it in.
+            try NewDocument.open(with: Bitmap(pasteboard: board))
         } catch {
             present("That image could not be opened.", error.localizedDescription)
         }

--- a/App/Model/ImageService.swift
+++ b/App/Model/ImageService.swift
@@ -1,0 +1,115 @@
+import AppKit
+import PaintKit
+import UniformTypeIdentifiers
+
+/// "Edit in ItsPaint", wherever macOS already offers to hand an image somewhere.
+///
+/// The Services menu is the oldest and cheapest of those doors: select an image
+/// in the Finder, or a picture in Mail or Safari, and the app appears under
+/// **Services** without being launched, without a share sheet, and without a
+/// single permission prompt. The pasteboard the system hands over is the grant —
+/// the sandbox lets us read exactly what the user chose to send and nothing else,
+/// which is the same bargain the open panel makes.
+///
+/// Registered at launch. `NSApp.servicesProvider` is what makes the `NSServices`
+/// entry in `Info.plist` do anything: without it the menu item appears, does
+/// nothing, and looks broken.
+@MainActor
+final class ImageService: NSObject {
+    static let shared = ImageService()
+
+    /// The most windows one invocation may open.
+    ///
+    /// Selecting a folder of screenshots in the Finder and picking a service is
+    /// one gesture, and without a ceiling it is one gesture that opens two
+    /// hundred windows. Ten is enough for the real case — a handful of shots for
+    /// one bug report — and small enough that the mistake is recoverable by hand.
+    ///
+    /// `nonisolated` because the filter below is, and a main-actor constant read
+    /// from a nonisolated function does not compile under strict concurrency.
+    nonisolated static let maxFiles = 10
+
+    /// Image files on a pasteboard, in name order, capped.
+    ///
+    /// Internal and `nonisolated` for the same reason the watcher's filter is:
+    /// this is the function that decides what gets opened, the bad outcome is a
+    /// screenful of windows, and a test has to be able to call it.
+    ///
+    /// Sorted because the cap has to be deterministic. Pasteboard order is the
+    /// selection order the sending app happened to use, so "the first ten" would
+    /// otherwise mean a different ten each time.
+    nonisolated static func openableFiles(on board: NSPasteboard) -> [URL] {
+        let urls = board.readObjects(forClasses: [NSURL.self]) as? [URL] ?? []
+
+        let images = urls.filter { url in
+            let values = try? url.resourceValues(forKeys: [.contentTypeKey, .isDirectoryKey])
+            guard values?.isDirectory != true, let type = values?.contentType else { return false }
+            return ImageCodec.readableContentTypes.contains { type.conforms(to: $0) }
+        }
+
+        return Array(images.sorted { $0.lastPathComponent < $1.lastPathComponent }
+            .prefix(maxFiles))
+    }
+
+    /// The Services entry point. The selector name is the `NSMessage` value in
+    /// `Info.plist`; changing one without the other silently unhooks the menu.
+    @objc func openImageFromService(
+        _ pasteboard: NSPasteboard,
+        userData: String?,
+        error: AutoreleasingUnsafeMutablePointer<NSString>
+    ) {
+        NSApp.activate(ignoringOtherApps: true)
+
+        let files = Self.openableFiles(on: pasteboard)
+        if !files.isEmpty {
+            for url in files {
+                NSDocumentController.shared.openDocument(withContentsOf: url, display: true) { _, _, _ in
+                    // Quiet on failure, as the watcher is: the file is still on
+                    // disk where the user left it, and a modal for something they
+                    // pointed at in another app is worse than an absent window.
+                }
+            }
+            return
+        }
+
+        // No file, but the sender may have put pixels on the pasteboard — a
+        // selection in Preview, an image dragged out of a web page.
+        guard Bitmap.canDecode(pasteboard: pasteboard) else {
+            error.pointee = "That is not an image ItsPaint can open." as NSString
+            return
+        }
+
+        do {
+            try NewDocument.open(with: Bitmap(pasteboard: pasteboard))
+        } catch let failure {
+            error.pointee = failure.localizedDescription as NSString
+        }
+    }
+}
+
+/// Opening a window on an image that came from outside any document.
+///
+/// Shared by the clipboard shortcut and the Services entry because both arrive
+/// the same way: an image from somewhere else, no document to put it in, and the
+/// wrong answer is pasting it into whatever happened to be frontmost.
+enum NewDocument {
+    @MainActor
+    static func open(with bitmap: Bitmap) throws {
+        guard let document = try NSDocumentController.shared
+            .openUntitledDocumentAndDisplay(false) as? DrawingDocument
+        else { throw NewDocumentError.noDocument }
+
+        // `load` rather than `replaceCanvas`: this is the document's initial
+        // content, not an edit to it. The undo-recording path would open a window
+        // already dirty, offering to save a file that never existed.
+        document.model.load(canvas: bitmap, metadata: nil)
+        document.makeWindowControllers()
+        document.showWindows()
+    }
+}
+
+enum NewDocumentError: LocalizedError {
+    case noDocument
+
+    var errorDescription: String? { "That image could not be opened." }
+}

--- a/App/Model/ItsPaintIntents.swift
+++ b/App/Model/ItsPaintIntents.swift
@@ -19,19 +19,28 @@ enum IntentImage: Equatable {
     case file(URL)
     case bytes(Data)
 
-    /// The declared type is checked here rather than on the `@Parameter`.
-    /// `supportedContentTypes:` would do it in the Shortcuts picker itself, and
-    /// it is macOS 15 only — this app runs on 14, so the filter has to live
-    /// somewhere a test can reach anyway.
+    /// The picker filters by type as well (`supportedTypeIdentifiers` on the
+    /// parameter), and this is the second check behind it: Shortcuts can hand an
+    /// action a file the picker never saw, and a type nobody looked at opens a
+    /// blank window instead of an error.
     ///
     /// A `nil` type is not a rejection. Shortcuts passes bytes with no type from
     /// plenty of steps, and the decoder is the honest oracle for those.
-    static func source(fileURL: URL?, data: Data?, type: UTType?) throws -> IntentImage {
+    ///
+    /// **`data` is an autoclosure on purpose.** `IntentFile.data` maps the file's
+    /// contents, and for an external file that read has to happen inside
+    /// `startAccessingSecurityScopedResource()`. Evaluating it as an argument
+    /// would do the read before the scope is open — a sandbox failure on the path
+    /// that was never going to use the bytes, and a needless map of a large file
+    /// on the path that was.
+    static func source(
+        fileURL: URL?, type: UTType?, data: @autoclosure () -> Data?
+    ) throws -> IntentImage {
         if let type, !type.conforms(to: .image), !type.conforms(to: .pdf) {
             throw IntentImageError.cannotDecode
         }
         if let fileURL, fileURL.isFileURL { return .file(fileURL) }
-        if let data, !data.isEmpty { return .bytes(data) }
+        if let bytes = data(), !bytes.isEmpty { return .bytes(bytes) }
         throw IntentImageError.nothingToOpen
     }
 }
@@ -66,7 +75,10 @@ struct OpenImageIntent: AppIntent {
     /// that completes in the background has done nothing anyone can see.
     static let openAppWhenRun = true
 
-    @Parameter(title: "Image")
+    /// `supportedTypeIdentifiers` rather than `supportedContentTypes`, which is
+    /// macOS 15. Without either, the parameter defaults to `public.item` and
+    /// Shortcuts offers to feed the action an archive or a sound file.
+    @Parameter(title: "Image", supportedTypeIdentifiers: ["public.image", "com.adobe.pdf"])
     var file: IntentFile
 
     static var parameterSummary: some ParameterSummary {
@@ -75,7 +87,7 @@ struct OpenImageIntent: AppIntent {
 
     @MainActor
     func perform() async throws -> some IntentResult {
-        switch try IntentImage.source(fileURL: file.fileURL, data: file.data, type: file.type) {
+        switch try IntentImage.source(fileURL: file.fileURL, type: file.type, data: file.data) {
         case .file(let url):
             // Shortcuts passes a security-scoped URL. Without the accessor the
             // read fails inside the sandbox, and the failure looks like a corrupt

--- a/App/Model/ItsPaintIntents.swift
+++ b/App/Model/ItsPaintIntents.swift
@@ -1,0 +1,117 @@
+import AppIntents
+import AppKit
+import PaintKit
+import UniformTypeIdentifiers
+
+/// Where a Shortcuts action's image actually comes from.
+///
+/// Shortcuts hands over an `IntentFile` that may carry a file on disk, bytes in
+/// memory, or both. The two routes are not interchangeable: a file URL keeps the
+/// document tied to a real path, so a save goes back where the image came from,
+/// while bytes can only ever become an untitled window. Preferring the URL is
+/// the whole difference between "mark up this screenshot" and "mark up a copy of
+/// this screenshot that you now have to file somewhere".
+///
+/// Split out and testable because the failure is silent: a wrong branch here
+/// still opens a window, and nobody notices until a save lands in the wrong
+/// place — or does not land at all.
+enum IntentImage: Equatable {
+    case file(URL)
+    case bytes(Data)
+
+    /// The declared type is checked here rather than on the `@Parameter`.
+    /// `supportedContentTypes:` would do it in the Shortcuts picker itself, and
+    /// it is macOS 15 only — this app runs on 14, so the filter has to live
+    /// somewhere a test can reach anyway.
+    ///
+    /// A `nil` type is not a rejection. Shortcuts passes bytes with no type from
+    /// plenty of steps, and the decoder is the honest oracle for those.
+    static func source(fileURL: URL?, data: Data?, type: UTType?) throws -> IntentImage {
+        if let type, !type.conforms(to: .image), !type.conforms(to: .pdf) {
+            throw IntentImageError.cannotDecode
+        }
+        if let fileURL, fileURL.isFileURL { return .file(fileURL) }
+        if let data, !data.isEmpty { return .bytes(data) }
+        throw IntentImageError.nothingToOpen
+    }
+}
+
+enum IntentImageError: LocalizedError {
+    case nothingToOpen
+    case cannotDecode
+
+    var errorDescription: String? {
+        switch self {
+        case .nothingToOpen: "That item has no image in it."
+        case .cannotDecode: "That is not an image ItsPaint can open."
+        }
+    }
+}
+
+/// "Open in ItsPaint" as a Shortcuts action.
+///
+/// The point is not automation for its own sake. A Shortcuts action is a door:
+/// it puts the app in the Shortcuts gallery, makes it reachable from Spotlight
+/// and a Quick Action, and lets someone put a markup step inside a shortcut they
+/// already run — none of which requires them to remember the app exists, which
+/// is the whole problem a paint app has.
+struct OpenImageIntent: AppIntent {
+    static let title: LocalizedStringResource = "Open Image in ItsPaint"
+
+    static let description = IntentDescription(
+        "Opens an image or PDF page in a new ItsPaint window, ready to mark up."
+    )
+
+    /// The window is the result, so the app has to come forward. A markup action
+    /// that completes in the background has done nothing anyone can see.
+    static let openAppWhenRun = true
+
+    @Parameter(title: "Image")
+    var file: IntentFile
+
+    static var parameterSummary: some ParameterSummary {
+        Summary("Open \(\.$file) in ItsPaint")
+    }
+
+    @MainActor
+    func perform() async throws -> some IntentResult {
+        switch try IntentImage.source(fileURL: file.fileURL, data: file.data, type: file.type) {
+        case .file(let url):
+            // Shortcuts passes a security-scoped URL. Without the accessor the
+            // read fails inside the sandbox, and the failure looks like a corrupt
+            // file rather than a missing grant.
+            let scoped = url.startAccessingSecurityScopedResource()
+            defer { if scoped { url.stopAccessingSecurityScopedResource() } }
+
+            try await NSDocumentController.shared.openDocument(
+                withContentsOf: url, display: true
+            )
+
+        case .bytes(let data):
+            guard let bitmap = ImageCodec.decode(data: data) else {
+                throw IntentImageError.cannotDecode
+            }
+            try NewDocument.open(with: bitmap)
+        }
+
+        return .result()
+    }
+}
+
+/// The phrases and the gallery tile.
+///
+/// One action, one tile. A provider that registers six variations of the same
+/// verb fills the gallery with noise and gets the app ignored in it.
+struct ItsPaintShortcuts: AppShortcutsProvider {
+    static var appShortcuts: [AppShortcut] {
+        AppShortcut(
+            intent: OpenImageIntent(),
+            phrases: [
+                "Open an image in \(.applicationName)",
+                "Mark up an image with \(.applicationName)",
+            ],
+            shortTitle: "Open Image",
+            systemImageName: "paintbrush.pointed"
+        )
+    }
+}

--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -109,6 +109,33 @@
 		</dict>
 	</array>
 
+	<!--
+	  "Edit in ItsPaint" in the Services menu, everywhere macOS offers one: the
+	  Finder, Mail, Safari, Preview. NSMessage must match the selector on
+	  ImageService, and the provider has to be assigned at launch or the item
+	  appears and does nothing.
+	-->
+	<key>NSServices</key>
+	<array>
+		<dict>
+			<key>NSMenuItem</key>
+			<dict>
+				<key>default</key>
+				<string>Edit in ItsPaint</string>
+			</dict>
+			<key>NSMessage</key>
+			<string>openImageFromService</string>
+			<key>NSPortName</key>
+			<string>ItsPaint</string>
+			<key>NSSendTypes</key>
+			<array>
+				<string>public.file-url</string>
+				<string>public.png</string>
+				<string>public.tiff</string>
+			</array>
+		</dict>
+	</array>
+
 	<key>UTExportedTypeDeclarations</key>
 	<array>
 		<dict>

--- a/App/Resources/Info.plist
+++ b/App/Resources/Info.plist
@@ -127,9 +127,20 @@
 			<string>openImageFromService</string>
 			<key>NSPortName</key>
 			<string>ItsPaint</string>
+			<!--
+			  Files go in NSSendFileTypes, not NSSendTypes. Every Finder selection
+			  offers public.file-url, so advertising that here would put "Edit in
+			  ItsPaint" on folders, archives and sound files, and the menu item
+			  would then do nothing. NSSendTypes stays for the pixels an app puts
+			  on the pasteboard directly.
+			-->
+			<key>NSSendFileTypes</key>
+			<array>
+				<string>public.image</string>
+				<string>com.adobe.pdf</string>
+			</array>
 			<key>NSSendTypes</key>
 			<array>
-				<string>public.file-url</string>
 				<string>public.png</string>
 				<string>public.tiff</string>
 			</array>

--- a/AppTests/ImageServiceTests.swift
+++ b/AppTests/ImageServiceTests.swift
@@ -1,0 +1,128 @@
+import AppKit
+import Foundation
+import Testing
+@testable import ItsPaint
+
+/// What "Edit in ItsPaint" is allowed to open.
+///
+/// The same failure the screenshot watcher guards against, arriving through a
+/// different door: the Services menu hands over whatever the user had selected,
+/// and a folder of two hundred screenshots is one click away from two hundred
+/// windows. This suite is the ceiling and the filter.
+@Suite("Edit in ItsPaint service")
+struct ImageServiceTests {
+
+    /// A 1x1 PNG, as real bytes. The filter reads each file's content type,
+    /// which comes from the data and not from the extension.
+    private static let onePixelPNG = Data(base64Encoded: """
+        iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==
+        """)!
+
+    private func makeFolder(_ build: (URL) throws -> Void) throws -> URL {
+        let folder = URL(fileURLWithPath: NSTemporaryDirectory())
+            .appendingPathComponent("service-\(UUID().uuidString)")
+        try FileManager.default.createDirectory(at: folder, withIntermediateDirectories: true)
+        try build(folder)
+        return folder
+    }
+
+    /// A pasteboard of our own, so a test never touches the machine's clipboard.
+    private func pasteboard(with urls: [URL]) -> NSPasteboard {
+        let board = NSPasteboard(name: NSPasteboard.Name("itspaint-test-\(UUID().uuidString)"))
+        board.clearContents()
+        board.writeObjects(urls.map { $0 as NSURL })
+        return board
+    }
+
+    @Test("Images are admitted, and nothing else is")
+    func admitsOnlyImages() throws {
+        let folder = try makeFolder { folder in
+            try Self.onePixelPNG.write(to: folder.appendingPathComponent("shot.png"))
+            try "notes".write(
+                to: folder.appendingPathComponent("notes.txt"), atomically: true, encoding: .utf8
+            )
+            try FileManager.default.createDirectory(
+                at: folder.appendingPathComponent("Archive"), withIntermediateDirectories: true
+            )
+        }
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let everything = try FileManager.default.contentsOfDirectory(
+            at: folder, includingPropertiesForKeys: nil
+        )
+        let admitted = ImageService.openableFiles(on: pasteboard(with: everything))
+
+        #expect(admitted.map(\.lastPathComponent) == ["shot.png"])
+    }
+
+    /// The ceiling, and the control that proves the ceiling is not just "ten".
+    ///
+    /// A cap implemented as an unconditional `prefix` would pass a test that only
+    /// checked the over-limit case, and would then be indistinguishable from a
+    /// filter that always returns ten — so the under-limit case is asserted too.
+    @Test("A selection above the cap is trimmed, and one below it is not")
+    func capsWithoutTruncatingSmallSelections() throws {
+        let over = try makeFolder { folder in
+            for index in 0..<(ImageService.maxFiles + 2) {
+                try Self.onePixelPNG.write(
+                    to: folder.appendingPathComponent(String(format: "shot-%02d.png", index))
+                )
+            }
+        }
+        let under = try makeFolder { folder in
+            for index in 0..<3 {
+                try Self.onePixelPNG.write(
+                    to: folder.appendingPathComponent("small-\(index).png")
+                )
+            }
+        }
+        defer {
+            try? FileManager.default.removeItem(at: over)
+            try? FileManager.default.removeItem(at: under)
+        }
+
+        let overFiles = try FileManager.default.contentsOfDirectory(
+            at: over, includingPropertiesForKeys: nil
+        )
+        let underFiles = try FileManager.default.contentsOfDirectory(
+            at: under, includingPropertiesForKeys: nil
+        )
+
+        #expect(overFiles.count == ImageService.maxFiles + 2)
+        #expect(ImageService.openableFiles(on: pasteboard(with: overFiles)).count
+            == ImageService.maxFiles)
+        #expect(ImageService.openableFiles(on: pasteboard(with: underFiles)).count == 3)
+    }
+
+    /// Which ten, when there are more than ten.
+    ///
+    /// Pasteboard order is whatever order the sending app wrote, so without a
+    /// sort the cap keeps an arbitrary and unrepeatable subset.
+    @Test("The kept files are the first by name, not by pasteboard order")
+    func capIsDeterministic() throws {
+        let folder = try makeFolder { folder in
+            for index in 0..<(ImageService.maxFiles + 2) {
+                try Self.onePixelPNG.write(
+                    to: folder.appendingPathComponent(String(format: "shot-%02d.png", index))
+                )
+            }
+        }
+        defer { try? FileManager.default.removeItem(at: folder) }
+
+        let files = try FileManager.default.contentsOfDirectory(
+            at: folder, includingPropertiesForKeys: nil
+        )
+        let kept = ImageService.openableFiles(on: pasteboard(with: files.reversed()))
+
+        #expect(kept.map(\.lastPathComponent)
+            == (0..<ImageService.maxFiles).map { String(format: "shot-%02d.png", $0) })
+    }
+
+    /// An empty pasteboard must come back empty rather than throwing, because
+    /// the service is reachable from any app and some of them send nothing
+    /// useful at all.
+    @Test("Nothing on the pasteboard admits nothing")
+    func emptyPasteboardAdmitsNothing() {
+        #expect(ImageService.openableFiles(on: pasteboard(with: [])).isEmpty)
+    }
+}

--- a/AppTests/IntentImageTests.swift
+++ b/AppTests/IntentImageTests.swift
@@ -1,0 +1,72 @@
+import Foundation
+import Testing
+import UniformTypeIdentifiers
+@testable import ItsPaint
+
+/// Which of the two things a Shortcuts action can hand over gets opened.
+///
+/// The bug this suite exists for does not crash and does not show an error: pick
+/// the bytes when a file URL was available and the window opens fine, untitled,
+/// so a save goes to a panel instead of back to the screenshot it came from.
+@Suite("Shortcuts image source")
+struct IntentImageTests {
+
+    private static let onePixelPNG = Data(base64Encoded: """
+        iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mP8z8DwHwAFAAH/q842iQAAAABJRU5ErkJggg==
+        """)!
+
+    @Test("A file on disk wins, even when the bytes are there too")
+    func fileBeatsBytes() throws {
+        let url = URL(fileURLWithPath: "/tmp/shot.png")
+
+        #expect(try IntentImage.source(fileURL: url, data: Self.onePixelPNG, type: .png) == .file(url))
+    }
+
+    @Test("Bytes are used when there is no file")
+    func bytesWithoutFile() throws {
+        #expect(try IntentImage.source(fileURL: nil, data: Self.onePixelPNG, type: .png)
+            == .bytes(Self.onePixelPNG))
+    }
+
+    /// A remote URL is not a file. Shortcuts can pass one through from a web
+    /// step, and handing it to the document controller opens nothing.
+    @Test("A non-file URL falls through to the bytes")
+    func remoteURLIsNotAFile() throws {
+        let remote = URL(string: "https://example.com/shot.png")!
+
+        #expect(try IntentImage.source(fileURL: remote, data: Self.onePixelPNG, type: nil)
+            == .bytes(Self.onePixelPNG))
+    }
+
+    /// Nothing usable must be an error rather than a silently empty window: an
+    /// untitled canvas appearing in place of the image you asked for reads as the
+    /// app losing your file.
+    @Test("Neither a file nor bytes is an error")
+    func nothingIsAnError() {
+        #expect(throws: IntentImageError.self) {
+            try IntentImage.source(fileURL: nil, data: nil, type: nil)
+        }
+        #expect(throws: IntentImageError.self) {
+            try IntentImage.source(fileURL: nil, data: Data(), type: nil)
+        }
+    }
+
+    /// A type the app cannot open is refused before a window appears. Shortcuts
+    /// will hand over whatever the previous step produced, and a text file
+    /// opening as a blank canvas is worse than an error.
+    @Test("A type that is not an image or a PDF is refused")
+    func refusesOtherTypes() {
+        #expect(throws: IntentImageError.self) {
+            try IntentImage.source(fileURL: URL(fileURLWithPath: "/tmp/notes.txt"),
+                                   data: nil, type: .plainText)
+        }
+    }
+
+    /// A PDF is admitted, because 0.17.0 opens one as a page.
+    @Test("A PDF is admitted")
+    func admitsPDF() throws {
+        let url = URL(fileURLWithPath: "/tmp/contract.pdf")
+
+        #expect(try IntentImage.source(fileURL: url, data: nil, type: .pdf) == .file(url))
+    }
+}

--- a/AppTests/IntentImageTests.swift
+++ b/AppTests/IntentImageTests.swift
@@ -19,12 +19,12 @@ struct IntentImageTests {
     func fileBeatsBytes() throws {
         let url = URL(fileURLWithPath: "/tmp/shot.png")
 
-        #expect(try IntentImage.source(fileURL: url, data: Self.onePixelPNG, type: .png) == .file(url))
+        #expect(try IntentImage.source(fileURL: url, type: .png, data: Self.onePixelPNG) == .file(url))
     }
 
     @Test("Bytes are used when there is no file")
     func bytesWithoutFile() throws {
-        #expect(try IntentImage.source(fileURL: nil, data: Self.onePixelPNG, type: .png)
+        #expect(try IntentImage.source(fileURL: nil, type: .png, data: Self.onePixelPNG)
             == .bytes(Self.onePixelPNG))
     }
 
@@ -34,7 +34,7 @@ struct IntentImageTests {
     func remoteURLIsNotAFile() throws {
         let remote = URL(string: "https://example.com/shot.png")!
 
-        #expect(try IntentImage.source(fileURL: remote, data: Self.onePixelPNG, type: nil)
+        #expect(try IntentImage.source(fileURL: remote, type: nil, data: Self.onePixelPNG)
             == .bytes(Self.onePixelPNG))
     }
 
@@ -44,10 +44,10 @@ struct IntentImageTests {
     @Test("Neither a file nor bytes is an error")
     func nothingIsAnError() {
         #expect(throws: IntentImageError.self) {
-            try IntentImage.source(fileURL: nil, data: nil, type: nil)
+            try IntentImage.source(fileURL: nil, type: nil, data: nil)
         }
         #expect(throws: IntentImageError.self) {
-            try IntentImage.source(fileURL: nil, data: Data(), type: nil)
+            try IntentImage.source(fileURL: nil, type: nil, data: Data())
         }
     }
 
@@ -58,7 +58,7 @@ struct IntentImageTests {
     func refusesOtherTypes() {
         #expect(throws: IntentImageError.self) {
             try IntentImage.source(fileURL: URL(fileURLWithPath: "/tmp/notes.txt"),
-                                   data: nil, type: .plainText)
+                                   type: .plainText, data: nil)
         }
     }
 
@@ -67,6 +67,25 @@ struct IntentImageTests {
     func admitsPDF() throws {
         let url = URL(fileURLWithPath: "/tmp/contract.pdf")
 
-        #expect(try IntentImage.source(fileURL: url, data: nil, type: .pdf) == .file(url))
+        #expect(try IntentImage.source(fileURL: url, type: .pdf, data: nil) == .file(url))
+    }
+
+    /// The bytes must not be touched when a file URL is going to win.
+    ///
+    /// `IntentFile.data` maps the file, and for an external file that read only
+    /// succeeds inside a security scope this function's caller has not opened
+    /// yet. A plain parameter would be evaluated at the call site — this asserts
+    /// the autoclosure is not.
+    @Test("The bytes are not read when a file wins")
+    func fileBranchNeverReadsBytes() throws {
+        nonisolated(unsafe) var reads = 0
+        let url = URL(fileURLWithPath: "/tmp/shot.png")
+
+        _ = try IntentImage.source(fileURL: url, type: .png, data: {
+            reads += 1
+            return Self.onePixelPNG
+        }())
+
+        #expect(reads == 0)
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,11 @@ version may still carry breaking changes to the document format.
 - **Edit in ItsPaint, from the Services menu.** Select an image in the Finder, in
   Mail, in a web page — anywhere macOS offers Services — and it opens here. The
   pasteboard the system hands over is the entire grant, so this needs no new
-  entitlement and asks for no permission. **Ten files at a time, in name order:**
+  entitlement and asks for no permission. The supported types are declared under
+  `NSSendFileTypes` rather than `NSSendTypes`: every Finder selection offers
+  `public.file-url`, so the generic route would have put the item on folders,
+  archives and sound files and then done nothing when it was chosen. **Ten files
+  at a time, in name order:**
   choosing a service with a folder of screenshots selected is one gesture, and
   without a ceiling it is one gesture that opens two hundred windows. The order
   matters because pasteboard order is whatever the sending app used, so "the
@@ -20,10 +24,15 @@ version may still carry breaking changes to the document format.
   inside a shortcut somebody already runs, which is a door into the app that does
   not require remembering it exists. It takes an image or a PDF page and prefers
   a file on disk over the bytes beside it — a document tied to a real path saves
-  back where the image came from, and an untitled one sends you to a panel. The
-  type check lives in the app rather than on the parameter because
-  `supportedContentTypes:` is macOS 15 and this app runs on 14; putting it in code
-  also put it under test.
+  back where the image came from, and an untitled one sends you to a panel, and
+  the wrong branch there still opens a window, so nothing would catch it until a
+  save went missing. The Shortcuts picker filters by type
+  (`supportedTypeIdentifiers`, because `supportedContentTypes` is macOS 15 and
+  this app runs on 14) and the action checks again on the way in, because
+  Shortcuts can hand an action a file its picker never offered. The bytes are read
+  through an autoclosure so the file branch never maps them: `IntentFile.data`
+  reads the file, and for an external file that read has to happen inside the
+  security scope the caller has not opened yet.
 
 ### Changed
 - **The clipboard shortcut and the Services entry now open a window the same

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ Notable changes, newest first. This project follows
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html). Until 1.0 the minor
 version may still carry breaking changes to the document format.
 
+## [Unreleased]
+
+### Added
+- **Edit in ItsPaint, from the Services menu.** Select an image in the Finder, in
+  Mail, in a web page — anywhere macOS offers Services — and it opens here. The
+  pasteboard the system hands over is the entire grant, so this needs no new
+  entitlement and asks for no permission. **Ten files at a time, in name order:**
+  choosing a service with a folder of screenshots selected is one gesture, and
+  without a ceiling it is one gesture that opens two hundred windows. The order
+  matters because pasteboard order is whatever the sending app used, so "the
+  first ten" would otherwise be a different ten each time.
+- **A Shortcuts action, Open Image in ItsPaint.** A markup step can now sit
+  inside a shortcut somebody already runs, which is a door into the app that does
+  not require remembering it exists. It takes an image or a PDF page and prefers
+  a file on disk over the bytes beside it — a document tied to a real path saves
+  back where the image came from, and an untitled one sends you to a panel. The
+  type check lives in the app rather than on the parameter because
+  `supportedContentTypes:` is macOS 15 and this app runs on 14; putting it in code
+  also put it under test.
+
+### Changed
+- **The clipboard shortcut and the Services entry now open a window the same
+  way.** Both arrive with an image from somewhere else and no document to put it
+  in, and both were about to grow their own copy of the "make an untitled
+  document, load it, show it" dance.
+
 ## [0.17.0] — 2026-08-22
 
 ### Added

--- a/ItsPaint.xcodeproj/project.pbxproj
+++ b/ItsPaint.xcodeproj/project.pbxproj
@@ -25,11 +25,13 @@
 		48905D56B247546BA33C44F8 /* ItsPaintApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 14E7B1F407FDB6F47C079660 /* ItsPaintApp.swift */; };
 		4BC22C9E41431096754A0997 /* PaintKit in Frameworks */ = {isa = PBXBuildFile; productRef = 61964C2B3FE22724FE4E4A8B /* PaintKit */; };
 		530689DA33232E54BB8DFD63 /* ToolRail.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7833326AD2D84AF29B6DE601 /* ToolRail.swift */; };
+		531FB0243541A216A57A5D38 /* ImageServiceTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = CCB01892F8CC5C23F9945754 /* ImageServiceTests.swift */; };
 		57E1D3BD09515B40DFDBEDD9 /* ColourPanelController.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1EC319E836430BA852D8EDB0 /* ColourPanelController.swift */; };
 		5B6FFEF7D300E81FCAE852C6 /* DesignTokens.swift in Sources */ = {isa = PBXBuildFile; fileRef = 392ADD8A7EEC36D1855BA3D5 /* DesignTokens.swift */; };
 		623D371268183070226716CB /* SettingsWindow.swift in Sources */ = {isa = PBXBuildFile; fileRef = 1BDFB5F76AC906C0238C2DA8 /* SettingsWindow.swift */; };
 		62EE08BC08488DAE1C672EB1 /* EditorView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6E86C21F2F8518B426159B77 /* EditorView.swift */; };
 		6B8140C107D4A209AD6CD789 /* RotateSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = 86C35AB5A1478944CF8934D3 /* RotateSheet.swift */; };
+		6E325B82DDA5E30912DF55E1 /* ImageService.swift in Sources */ = {isa = PBXBuildFile; fileRef = 5A234942D3EA68BA706E4526 /* ImageService.swift */; };
 		70251274389D468920E0FF44 /* DrawingDocument.swift in Sources */ = {isa = PBXBuildFile; fileRef = 18BC1714C722B756C83FFF6E /* DrawingDocument.swift */; };
 		71B8FC7E198B4F762F94C6A2 /* DocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F4A9F5632360B181403BDA /* DocumentTests.swift */; };
 		736B873DA05CA677039DB143 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 81D5AB95221C3E1A9DD3CFC7 /* Assets.xcassets */; };
@@ -38,10 +40,12 @@
 		8CFB1C6C1779CAF721DD34EA /* FixedGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80562B1588560C2E61CCE65 /* FixedGrid.swift */; };
 		8DE72B90DE9FDDBCEA63C2FD /* ClipboardHotKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951512EED8AAC0B1B7716D54 /* ClipboardHotKey.swift */; };
 		924C2B7A35DD5F3985A29406 /* EssentialsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E4A12B57303E5FE405DFC /* EssentialsTests.swift */; };
+		930F1913FD1187A5A7007258 /* ItsPaintIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B939C1CD497C7F8334FFD0B /* ItsPaintIntents.swift */; };
 		95E1D3A13CB44069D1DAE0AC /* DocumentCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEF09B51CF5FC0B71765BA1 /* DocumentCommands.swift */; };
 		970A38652FFECA2910FFAAFF /* CanvasOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8468DB5919B3A21F63903298 /* CanvasOverlays.swift */; };
 		979898D93E97297A55E27038 /* ScreenshotWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0EAC5ED7B22052E9BBBE8C9 /* ScreenshotWatcher.swift */; };
 		A75FAC3C0CD78F3C12737311 /* Tooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D10B48F97C15A6294B5737E /* Tooltip.swift */; };
+		A8567364BE05578FC20DCD4C /* IntentImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D68AE3B45C7E5A426262AB /* IntentImageTests.swift */; };
 		C01A38C39B6208DD8B4D43BD /* TooltipRenderTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = B7C5F03C386722F20FEE3E4A /* TooltipRenderTests.swift */; };
 		C8F6D5D56AB4B3B9C07FC626 /* Mark.swift in Sources */ = {isa = PBXBuildFile; fileRef = A822F8D017517676617751C9 /* Mark.swift */; };
 		CA7E69B188CC2D88EC2CE781 /* EditorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B04711CAED447B409481B1 /* EditorModel.swift */; };
@@ -74,16 +78,19 @@
 		1EC319E836430BA852D8EDB0 /* ColourPanelController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColourPanelController.swift; sourceTree = "<group>"; };
 		20B04711CAED447B409481B1 /* EditorModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorModel.swift; sourceTree = "<group>"; };
 		30AE5E34F15348E6ACA11DFC /* ItsPaintTests.xctest */ = {isa = PBXFileReference; explicitFileType = wrapper.cfbundle; includeInIndex = 0; path = ItsPaintTests.xctest; sourceTree = BUILT_PRODUCTS_DIR; };
+		34D68AE3B45C7E5A426262AB /* IntentImageTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntentImageTests.swift; sourceTree = "<group>"; };
 		392ADD8A7EEC36D1855BA3D5 /* DesignTokens.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DesignTokens.swift; sourceTree = "<group>"; };
 		3ABAEBA2B88281FDAA9CF273 /* Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist; path = Info.plist; sourceTree = "<group>"; };
 		54F4A9F5632360B181403BDA /* DocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DocumentTests.swift; sourceTree = "<group>"; };
 		57CB1F5FDC405482E21278EA /* ItsPaint.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = ItsPaint.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		5838B6603DAE5E9838603224 /* DraggedImage.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DraggedImage.swift; sourceTree = "<group>"; };
+		5A234942D3EA68BA706E4526 /* ImageService.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageService.swift; sourceTree = "<group>"; };
 		605B317CA16CD2D068DF970B /* TextEditorLayoutTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TextEditorLayoutTests.swift; sourceTree = "<group>"; };
 		60DC85A97B97F5CFF1EEBFE4 /* CanvasScrollView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasScrollView.swift; sourceTree = "<group>"; };
 		6BCA68F035B62041B06BC57D /* SigningStrip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SigningStrip.swift; sourceTree = "<group>"; };
 		6E86C21F2F8518B426159B77 /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
 		7833326AD2D84AF29B6DE601 /* ToolRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRail.swift; sourceTree = "<group>"; };
+		7B939C1CD497C7F8334FFD0B /* ItsPaintIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItsPaintIntents.swift; sourceTree = "<group>"; };
 		81D5AB95221C3E1A9DD3CFC7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8468DB5919B3A21F63903298 /* CanvasOverlays.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasOverlays.swift; sourceTree = "<group>"; };
 		86C35AB5A1478944CF8934D3 /* RotateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotateSheet.swift; sourceTree = "<group>"; };
@@ -98,6 +105,7 @@
 		C06E4A12B57303E5FE405DFC /* EssentialsTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EssentialsTests.swift; sourceTree = "<group>"; };
 		C83A429AB8B62EFEDC176D65 /* ColourPopover.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ColourPopover.swift; sourceTree = "<group>"; };
 		CA3B7CF910C5BF4084044565 /* PaintKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PaintKit; path = Packages/PaintKit; sourceTree = SOURCE_ROOT; };
+		CCB01892F8CC5C23F9945754 /* ImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageServiceTests.swift; sourceTree = "<group>"; };
 		D072F2FA0424641934102963 /* PDFDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFDocumentTests.swift; sourceTree = "<group>"; };
 		E80562B1588560C2E61CCE65 /* FixedGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedGrid.swift; sourceTree = "<group>"; };
 		EA6F6F30090979763C866F84 /* SignatureSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureSheet.swift; sourceTree = "<group>"; };
@@ -178,6 +186,8 @@
 				11CCE83773644C45A0171C62 /* CanvasRenderingTests.swift */,
 				54F4A9F5632360B181403BDA /* DocumentTests.swift */,
 				C06E4A12B57303E5FE405DFC /* EssentialsTests.swift */,
+				CCB01892F8CC5C23F9945754 /* ImageServiceTests.swift */,
+				34D68AE3B45C7E5A426262AB /* IntentImageTests.swift */,
 				B063B5E24D6EBB4CEB198E5B /* PasteGrowthTests.swift */,
 				D072F2FA0424641934102963 /* PDFDocumentTests.swift */,
 				073EFE49D21C2976F9D72BB4 /* ScreenshotWatcherTests.swift */,
@@ -196,6 +206,8 @@
 				951512EED8AAC0B1B7716D54 /* ClipboardHotKey.swift */,
 				5838B6603DAE5E9838603224 /* DraggedImage.swift */,
 				20B04711CAED447B409481B1 /* EditorModel.swift */,
+				5A234942D3EA68BA706E4526 /* ImageService.swift */,
+				7B939C1CD497C7F8334FFD0B /* ItsPaintIntents.swift */,
 				B0EAC5ED7B22052E9BBBE8C9 /* ScreenshotWatcher.swift */,
 			);
 			path = Model;
@@ -364,7 +376,9 @@
 				CA7E69B188CC2D88EC2CE781 /* EditorModel.swift in Sources */,
 				62EE08BC08488DAE1C672EB1 /* EditorView.swift in Sources */,
 				8CFB1C6C1779CAF721DD34EA /* FixedGrid.swift in Sources */,
+				6E325B82DDA5E30912DF55E1 /* ImageService.swift in Sources */,
 				48905D56B247546BA33C44F8 /* ItsPaintApp.swift in Sources */,
+				930F1913FD1187A5A7007258 /* ItsPaintIntents.swift in Sources */,
 				1976F8F0D1BA69C8D0910DED /* MainMenuBuilder.swift in Sources */,
 				C8F6D5D56AB4B3B9C07FC626 /* Mark.swift in Sources */,
 				6B8140C107D4A209AD6CD789 /* RotateSheet.swift in Sources */,
@@ -387,6 +401,8 @@
 				397D8480B03F1D4E483412F6 /* CanvasRenderingTests.swift in Sources */,
 				71B8FC7E198B4F762F94C6A2 /* DocumentTests.swift in Sources */,
 				924C2B7A35DD5F3985A29406 /* EssentialsTests.swift in Sources */,
+				531FB0243541A216A57A5D38 /* ImageServiceTests.swift in Sources */,
+				A8567364BE05578FC20DCD4C /* IntentImageTests.swift in Sources */,
 				7D7E217925BBD597F47772AE /* PDFDocumentTests.swift in Sources */,
 				1DE130CDBF4B6616B66BF5F1 /* PasteGrowthTests.swift in Sources */,
 				F0389C97B6274DF2552FE2B9 /* ScreenshotWatcherTests.swift in Sources */,

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing protocol
 
-476 tests cover the engine and the Mac app. This document explains what each
+486 tests cover the engine and the Mac app. This document explains what each
 suite is for, how to write a test that will still be useful in a year, and the
 three failure modes that have already cost a day each.
 

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing protocol
 
-486 tests cover the engine and the Mac app. This document explains what each
+487 tests cover the engine and the Mac app. This document explains what each
 suite is for, how to write a test that will still be useful in a year, and the
 three failure modes that have already cost a day each.
 


### PR DESCRIPTION
Two of the three integration surfaces 1.0 is nominated on, both of which need no permission and no new entitlement.

**Services.** "Edit in ItsPaint" appears on any image in the Finder, Mail, or a web page. The pasteboard the system hands over is the entire grant — the same bargain the open panel makes. Capped at ten files, sorted by name: choosing a service with a folder of screenshots selected is one gesture, and without a ceiling it is one gesture that opens two hundred windows. Sorted because pasteboard order is whatever the sending app used, so "the first ten" would otherwise be a different ten each time.

**Shortcuts.** An `Open Image in ItsPaint` action, so a markup step can live inside a shortcut somebody already runs. It prefers a file on disk over the bytes beside it: a document tied to a real path saves back where the image came from, an untitled one sends you to a panel. That is the silent failure this PR's tests exist for — the wrong branch still opens a window, and nobody notices until a save goes missing. The type check is in code rather than on the `@Parameter` because `supportedContentTypes:` is macOS 15 and this app runs on 14; putting it in code also put it under test.

The clipboard shortcut and the Services entry now share one `NewDocument.open` rather than each carrying its own copy of make-untitled-document-load-show.

### Proof

`xcodebuild test` — **148 app tests in 20 suites, all passing** (138 before). The ten new ones are the two filters, and each carries the control that keeps it honest: the cap suite asserts an under-limit selection is *not* trimmed, so a `prefix` that always returned ten could not pass; the Shortcuts suite asserts a text file is refused and a PDF is admitted.

Not in this PR: the share extension, which is a new target with its own provisioning.