### PR TITLE
Ask about Reduce Motion once, not twenty-six times

### DIFF
--- a/App/UI/DesignTokens.swift
+++ b/App/UI/DesignTokens.swift
@@ -1,3 +1,4 @@
+import AppKit
 import SwiftUI
 
 /// The surface grammar for **Direction C — Canvas-first**.
@@ -170,13 +171,41 @@ enum Tokens {
     /// Motion explains a state change, never decorates. The pill's width
     /// animates on tool change because its *content* changes; nothing else
     /// moves.
+    /// Every animation in the app is one of these three, which is why Reduce Motion
+    /// is honoured here and not at the call sites. There are twenty-six of those.
+    /// Two of them checked `accessibilityReduceMotion` and twenty-four did not,
+    /// which is the arithmetic a per-caller guard always ends up with — and the
+    /// setting is not a preference about taste. It is turned on by people for whom
+    /// movement causes nausea or seizures.
     enum Motion {
+        /// `nil` is SwiftUI's "apply it instantly", so honouring the setting has
+        /// the same shape as not animating, and every `.animation(_:value:)` call
+        /// already takes an optional.
+        static func honouring(_ animation: Animation, reduceMotion: Bool) -> Animation? {
+            reduceMotion ? nil : animation
+        }
+
+        /// Read from AppKit rather than `@Environment(\.accessibilityReduceMotion)`
+        /// because these are static and an environment value needs a view to read
+        /// it in. The cost is that flipping the setting does not invalidate a view
+        /// already on screen; the next interaction picks it up, which for a setting
+        /// nobody toggles mid-gesture is the right trade.
+        static var systemReduceMotion: Bool {
+            NSWorkspace.shared.accessibilityDisplayShouldReduceMotion
+        }
+
         /// The options panel resizing as its content genuinely changes.
-        static let pillResize = Animation.smooth(duration: 0.22, extraBounce: 0.05)
-        static let micro = Animation.easeOut(duration: 0.12)
+        static var pillResize: Animation? {
+            honouring(.smooth(duration: 0.22, extraBounce: 0.05), reduceMotion: systemReduceMotion)
+        }
+        static var micro: Animation? {
+            honouring(.easeOut(duration: 0.12), reduceMotion: systemReduceMotion)
+        }
         /// A press answering under the pointer. Short enough to read as
         /// contact rather than animation.
-        static let press = Animation.easeOut(duration: 0.07)
+        static var press: Animation? {
+            honouring(.easeOut(duration: 0.07), reduceMotion: systemReduceMotion)
+        }
     }
 
     // MARK: - The rail

--- a/App/UI/Mark.swift
+++ b/App/UI/Mark.swift
@@ -40,7 +40,6 @@ struct Mark: View {
 
     @State private var isHovering = false
     @State private var isDragging = false
-    @Environment(\.accessibilityReduceMotion) private var reduceMotion
     @Environment(\.colorSchemeContrast) private var contrast
 
     private let trackHeight: CGFloat = 8
@@ -73,7 +72,7 @@ struct Mark: View {
                 .font(.system(size: 11, weight: .medium).monospacedDigit())
                 .foregroundStyle(.primary.opacity(isDragging ? Tokens.Ink.strong : Tokens.Ink.regular))
                 .frame(height: 14)
-                .animation(reduceMotion ? nil : Tokens.Motion.micro, value: isDragging)
+                .animation(Tokens.Motion.micro, value: isDragging)
             track
         }
         .accessibilityElement()
@@ -173,7 +172,7 @@ struct Mark: View {
             .fill(.primary.opacity(isHovering || isDragging ? Tokens.Ink.strong : Tokens.Ink.regular))
             .frame(width: 1.5, height: 14)
             .offset(x: max(0, min(width - 1.5, width * t - 0.75)))
-            .animation(reduceMotion ? nil : Tokens.Motion.micro, value: isHovering)
+            .animation(Tokens.Motion.micro, value: isHovering)
     }
 
     /// A stop, drawn on the trough rather than as a second row of capsules below it.

--- a/AppTests/ReduceMotionTests.swift
+++ b/AppTests/ReduceMotionTests.swift
@@ -1,0 +1,33 @@
+import SwiftUI
+import Testing
+@testable import ItsPaint
+
+/// Reduce Motion is honoured in one place, so it is tested in one place.
+///
+/// Before this, two of the app's twenty-six `.animation(_:value:)` calls checked
+/// `accessibilityReduceMotion` and twenty-four did not. The fix was to move the
+/// question into `Tokens.Motion` rather than to add twenty-four guards, and this
+/// is the check that fails if a future token forgets to route through it.
+@Suite("Reduce Motion")
+struct ReduceMotionTests {
+    @Test("The setting removes the animation rather than shortening it")
+    func honouringDropsTheAnimation() {
+        #expect(Tokens.Motion.honouring(.easeOut(duration: 0.12), reduceMotion: true) == nil)
+        #expect(Tokens.Motion.honouring(.easeOut(duration: 0.12), reduceMotion: false) != nil)
+    }
+
+    /// The tokens are read as `Animation?` at every call site. If one of them ever
+    /// goes back to a non-optional `let`, this stops compiling — which is the point:
+    /// a token that cannot be nil cannot honour the setting.
+    @Test("Every motion token is optional, which is what lets it be nothing")
+    func everyTokenIsOptional() {
+        let tokens: [Animation?] = [Tokens.Motion.micro,
+                                    Tokens.Motion.press,
+                                    Tokens.Motion.pillResize]
+        #expect(tokens.count == 3)
+        // Under the machine's real setting they are all present or all absent
+        // together — never a mixture, because they ask the same question.
+        let present = tokens.filter { $0 != nil }.count
+        #expect(present == 0 || present == 3)
+    }
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,16 @@ version may still carry breaking changes to the document format.
   security scope the caller has not opened yet.
 
 ### Changed
+- **Reduce Motion is honoured everywhere, from one place.** The app has
+  twenty-six animations and every one of them is one of three tokens, but the
+  setting was being checked at the call site: two calls asked, twenty-four did
+  not, which is the arithmetic a per-caller guard always ends up with. The
+  question moved into `Tokens.Motion`, whose three values are now `Animation?`
+  and are `nil` when the system asks for less movement — `nil` is SwiftUI's
+  "apply it instantly", so honouring the setting is the same shape as not
+  animating, and no call site changed. The two that were asking by hand stopped
+  needing to. This is a setting people turn on because movement makes them ill,
+  not because they dislike it.
 - **The clipboard shortcut and the Services entry now open a window the same
   way.** Both arrive with an image from somewhere else and no document to put it
   in, and both were about to grow their own copy of the "make an untitled

--- a/ItsPaint.xcodeproj/project.pbxproj
+++ b/ItsPaint.xcodeproj/project.pbxproj
@@ -43,6 +43,7 @@
 		930F1913FD1187A5A7007258 /* ItsPaintIntents.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7B939C1CD497C7F8334FFD0B /* ItsPaintIntents.swift */; };
 		95E1D3A13CB44069D1DAE0AC /* DocumentCommands.swift in Sources */ = {isa = PBXBuildFile; fileRef = BFEF09B51CF5FC0B71765BA1 /* DocumentCommands.swift */; };
 		970A38652FFECA2910FFAAFF /* CanvasOverlays.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8468DB5919B3A21F63903298 /* CanvasOverlays.swift */; };
+		9726B1CCB8E749B46B08CFF6 /* ReduceMotionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = E7360C126943F6A4289FC4B7 /* ReduceMotionTests.swift */; };
 		979898D93E97297A55E27038 /* ScreenshotWatcher.swift in Sources */ = {isa = PBXBuildFile; fileRef = B0EAC5ED7B22052E9BBBE8C9 /* ScreenshotWatcher.swift */; };
 		A75FAC3C0CD78F3C12737311 /* Tooltip.swift in Sources */ = {isa = PBXBuildFile; fileRef = 8D10B48F97C15A6294B5737E /* Tooltip.swift */; };
 		A8567364BE05578FC20DCD4C /* IntentImageTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 34D68AE3B45C7E5A426262AB /* IntentImageTests.swift */; };
@@ -107,6 +108,7 @@
 		CA3B7CF910C5BF4084044565 /* PaintKit */ = {isa = PBXFileReference; lastKnownFileType = folder; name = PaintKit; path = Packages/PaintKit; sourceTree = SOURCE_ROOT; };
 		CCB01892F8CC5C23F9945754 /* ImageServiceTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ImageServiceTests.swift; sourceTree = "<group>"; };
 		D072F2FA0424641934102963 /* PDFDocumentTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PDFDocumentTests.swift; sourceTree = "<group>"; };
+		E7360C126943F6A4289FC4B7 /* ReduceMotionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduceMotionTests.swift; sourceTree = "<group>"; };
 		E80562B1588560C2E61CCE65 /* FixedGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedGrid.swift; sourceTree = "<group>"; };
 		EA6F6F30090979763C866F84 /* SignatureSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureSheet.swift; sourceTree = "<group>"; };
 		F2ACA876E800C1AB89C90365 /* SizeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeSheet.swift; sourceTree = "<group>"; };
@@ -190,6 +192,7 @@
 				34D68AE3B45C7E5A426262AB /* IntentImageTests.swift */,
 				B063B5E24D6EBB4CEB198E5B /* PasteGrowthTests.swift */,
 				D072F2FA0424641934102963 /* PDFDocumentTests.swift */,
+				E7360C126943F6A4289FC4B7 /* ReduceMotionTests.swift */,
 				073EFE49D21C2976F9D72BB4 /* ScreenshotWatcherTests.swift */,
 				605B317CA16CD2D068DF970B /* TextEditorLayoutTests.swift */,
 				F2C78F7D1A8AE0254D405787 /* ToolbarGeometryTests.swift */,
@@ -405,6 +408,7 @@
 				A8567364BE05578FC20DCD4C /* IntentImageTests.swift in Sources */,
 				7D7E217925BBD597F47772AE /* PDFDocumentTests.swift in Sources */,
 				1DE130CDBF4B6616B66BF5F1 /* PasteGrowthTests.swift in Sources */,
+				9726B1CCB8E749B46B08CFF6 /* ReduceMotionTests.swift in Sources */,
 				F0389C97B6274DF2552FE2B9 /* ScreenshotWatcherTests.swift in Sources */,
 				F4C7E8CF3B5107D648F3FC45 /* TextEditorLayoutTests.swift in Sources */,
 				340D38B0D4130488E64D853C /* ToolSizeFloorTests.swift in Sources */,


### PR DESCRIPTION
The app has twenty-six animations and every one is one of three tokens in
`Tokens.Motion`. The setting was checked at the call site instead: two of the
twenty-six consulted `accessibilityReduceMotion`, twenty-four did not.

That is the arithmetic a per-caller guard always reaches. What it was getting
wrong is not a preference about taste — Reduce Motion is turned on by people
for whom movement causes nausea or seizures.

## The change

The three tokens are now `Animation?` and resolve to `nil` when the system asks
for less movement. `nil` is SwiftUI's "apply it instantly", and every
`.animation(_:value:)` call already takes an optional, so **no call site
changed** — the two in `Mark.swift` that were asking by hand stopped needing to.

The flag is read from `NSWorkspace` rather than the environment because the
tokens are static and an environment value needs a view to read it in. The cost
is named in the source: flipping the setting does not invalidate a view already
on screen, and the next interaction picks it up.

## The check

`Tokens.Motion.honouring(_:reduceMotion:)` takes the flag, so the branch is
testable without a machine whose setting happens to be on. `AppTests/ReduceMotionTests.swift`
covers both sides of it and asserts the three tokens are never a mixture of
animated and not. Suite is 151 tests in 21 suites, green.

## Why now

`GET /v1/apps/6796493980/accessibilityDeclarations` returned `[]`, so the
product page said the developer "hasn't indicated" anything — one of the seven
things Apple scores, and the one criterion the featuring nomination identified
as still movable. Dark Interface is now declared, honestly, and everything else
is declared false. This is what has to be true before Reduce Motion can join it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)