### PR TITLE
Export without an Xcode account

### DIFF
--- a/docs/APP_STORE.md
+++ b/docs/APP_STORE.md
@@ -26,6 +26,45 @@ Then either the web UI — **+** beside "macOS App" → the new version number �
 paste What's New → attach the build once Apple finishes processing it → Add
 for Review — or the API, which does the same thing without a browser.
 
+## Signing without an Xcode account
+
+The header above says Xcode must be signed in to the team account. That is one
+way and it is not the only one, which matters because a machine where Xcode has
+never been signed in fails **after a successful archive**, on the export, with
+`No signing certificate "Mac App Distribution" found` and `No Accounts`. That
+reads like a build problem and is an account problem.
+
+Mac App Store signing needs two certificates and a profile that the Developer ID
+release path does not:
+
+| | |
+|---|---|
+| `MAC_APP_DISTRIBUTION` | *3rd Party Mac Developer Application* — signs the app |
+| `MAC_INSTALLER_DISTRIBUTION` | *3rd Party Mac Developer Installer* — signs the pkg |
+| `MAC_APP_STORE` profile | ties the app certificate to the bundle id |
+
+All three can be made from the App Store Connect API with nothing but `openssl`,
+no Xcode session anywhere in it:
+
+1. `openssl req -new -newkey rsa:2048 -nodes -keyout k.key -out k.csr -subj "/CN=…"`
+2. `POST /v1/certificates` with `certificateType` and `csrContent`; base64-decode
+   `certificateContent` into a `.cer`. Once per type.
+3. `openssl x509 -inform DER` → PEM, `openssl pkcs12 -export -legacy` with the
+   key, then `security import … -T /usr/bin/codesign -T /usr/bin/productbuild
+   -T /usr/bin/productsign`.
+4. `POST /v1/profiles` with `profileType: MAC_APP_STORE`, the bundle id and the
+   app certificate; write `profileContent` to
+   `~/Library/MobileDevice/Provisioning Profiles/<uuid>.provisionprofile`.
+
+`scripts/appstore-archive.sh` picks the identities up from the keychain and
+switches the export to **manual** signing when both are present, so after step 4
+it just works. Automatic signing is still the fallback when they are not.
+
+**Uploading takes an API key too.** `destination: upload` authenticates as
+whichever account Xcode is signed in to — nothing, here. The script prefers
+`xcrun altool --upload-app --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"`,
+which reads the same `.p8` the rest of the release tooling uses.
+
 ## Submitting from the command line
 
 The whole update loop is App Store Connect API calls with an ES256 JWT signed

--- a/scripts/appstore-archive.sh
+++ b/scripts/appstore-archive.sh
@@ -127,7 +127,22 @@ if [[ "$SIGNATURE" == *"Signature=adhoc"* || "$SIGNATURE" != *"TeamIdentifier=$T
 fi
 echo "Archive signed by team $TEAM; the export re-signs it for distribution."
 
-cat > dist/appstore/ExportOptions.plist <<'PLIST'
+# Manual signing when the distribution identities are in the keychain.
+#
+# Automatic signing asks Xcode's account for anything it is missing, and on a
+# machine where Xcode has never been signed in that is every certificate: the
+# export fails with `No signing certificate "Mac App Distribution" found` and
+# `No Accounts`, after a successful archive, which reads like a build problem
+# and is an account problem. Naming the identities and the profile needs no
+# account at all. Both certificates can be created from the App Store Connect
+# API with nothing but openssl — see docs/APP_STORE.md.
+APP_ID_NAME="3rd Party Mac Developer Application: "
+INSTALLER_NAME="3rd Party Mac Developer Installer: "
+APP_CERT="$(security find-identity -v | sed -n "s/.*\"\(${APP_ID_NAME}[^\"]*\)\".*/\1/p" | head -1)"
+INSTALLER_CERT="$(security find-identity -v | sed -n "s/.*\"\(${INSTALLER_NAME}[^\"]*\)\".*/\1/p" | head -1)"
+
+{
+  cat <<'PLIST'
 <?xml version="1.0" encoding="UTF-8"?>
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
@@ -136,9 +151,19 @@ cat > dist/appstore/ExportOptions.plist <<'PLIST'
 	<string>app-store-connect</string>
 	<key>destination</key>
 	<string>export</string>
-</dict>
-</plist>
 PLIST
+  if [[ -n "$APP_CERT" && -n "$INSTALLER_CERT" ]]; then
+    echo "Signing manually as: $APP_CERT" >&2
+    printf '\t<key>teamID</key>\n\t<string>%s</string>\n' "$TEAM"
+    printf '\t<key>signingStyle</key>\n\t<string>manual</string>\n'
+    printf '\t<key>signingCertificate</key>\n\t<string>%s</string>\n' "$APP_CERT"
+    printf '\t<key>installerSigningCertificate</key>\n\t<string>%s</string>\n' "$INSTALLER_CERT"
+    printf '\t<key>provisioningProfiles</key>\n\t<dict>\n\t\t<key>com.joshlin.itspaint</key>\n\t\t<string>ItsPaint Mac App Store</string>\n\t</dict>\n'
+  else
+    echo "No Mac distribution identities in the keychain; falling back to automatic signing, which needs Xcode signed in." >&2
+  fi
+  printf '</dict>\n</plist>\n'
+} > dist/appstore/ExportOptions.plist
 
 xcodebuild -exportArchive -archivePath "$ARCHIVE" \
   -exportOptionsPlist dist/appstore/ExportOptions.plist \
@@ -156,15 +181,24 @@ if [[ "$UPLOAD" != "true" ]]; then
   exit 0
 fi
 
-# Uploading needs no API key: `destination: upload` authenticates as whichever
-# account Xcode is signed in to. A second export rather than `altool` on the
-# pkg above, because altool is the path that wants its own credentials.
-sed 's|<string>export</string>|<string>upload</string>|' \
-  dist/appstore/ExportOptions.plist > dist/appstore/UploadOptions.plist
-
-xcodebuild -exportArchive -archivePath "$ARCHIVE" \
-  -exportOptionsPlist dist/appstore/UploadOptions.plist \
-  -exportPath dist/appstore/upload ${EXTRA[@]+"${EXTRA[@]}"}
+# Two routes, and the one that used to be the only one needs an account.
+#
+# `destination: upload` authenticates as whichever account Xcode is signed in
+# to, which is nothing on a machine where it has never been signed in. altool
+# takes an App Store Connect API key instead, reading the .p8 from
+# ~/.appstoreconnect/private_keys, and is preferred here for exactly that
+# reason. The key is the same one the rest of the release tooling uses.
+if [[ -n "${ASC_KEY_ID:-}" && -n "${ASC_ISSUER_ID:-}" ]]; then
+  xcrun altool --upload-app -f "$PKG" -t macos \
+    --apiKey "$ASC_KEY_ID" --apiIssuer "$ASC_ISSUER_ID"
+else
+  echo "ASC_KEY_ID/ASC_ISSUER_ID unset; uploading as the account Xcode is signed in to." >&2
+  sed 's|<string>export</string>|<string>upload</string>|' \
+    dist/appstore/ExportOptions.plist > dist/appstore/UploadOptions.plist
+  xcodebuild -exportArchive -archivePath "$ARCHIVE" \
+    -exportOptionsPlist dist/appstore/UploadOptions.plist \
+    -exportPath dist/appstore/upload ${EXTRA[@]+"${EXTRA[@]}"}
+fi
 
 echo
 echo "Uploaded. The build appears in App Store Connect once Apple finishes"


### PR DESCRIPTION
`scripts/appstore-archive.sh` archives fine and its **export** failed tonight
with `No signing certificate "Mac App Distribution" found` and `No Accounts`.
The archive had already succeeded, so it reads like a build problem and is an
account problem: automatic signing asks Xcode's account for whatever is
missing, and on a machine where Xcode has never been signed in that is
everything.

**The export now uses manual signing when the identities are in the keychain.**
It reads the two `3rd Party Mac Developer …` identities out of
`security find-identity` and names them, plus the profile, in ExportOptions.
That needs no account at all. Automatic remains the fallback, and the script
says out loud which one it took.

**Uploading takes an API key too.** `destination: upload` authenticates as
whichever account Xcode is signed in to — nothing, here. It now prefers
`xcrun altool --upload-app --apiKey/--apiIssuer`, reading the same `.p8` the
rest of the release tooling uses, and falls back to the old route when those
are unset. The comment claiming uploading "needs no API key" was true only on a
machine with an Xcode session, which is not this one.

`docs/APP_STORE.md` gains the missing half: the two certificates and the
profile that Mac App Store signing needs and the Developer ID path does not,
and how to create all three from the App Store Connect API with `openssl`.

**Verified** by running the patched script end to end on a machine with no
Xcode account: `Signing manually as: 3rd Party Mac Developer Application`,
`** EXPORT SUCCEEDED **`, a pkg signed by the installer identity. 0.18.0 build
16 went to Apple this way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)