### PR TITLE
Build the App Store binary where the SDK is one Apple accepts

### DIFF
--- a/.github/workflows/appstore.yml
+++ b/.github/workflows/appstore.yml
@@ -1,0 +1,197 @@
+name: App Store build
+
+# WHY THIS EXISTS, and why the build cannot happen on a laptop.
+#
+# On 2026-08-25 build 16 was archived, signed, uploaded and rejected by Apple:
+#
+#   ITMS-90301: This bundle is invalid — Apple is not currently accepting
+#   applications built with this version of the OS.
+#
+# The machine that built it had exactly one Xcode, a beta, whose only macOS SDK
+# was a beta SDK. Nothing about the archive was wrong; the SDK recorded in the
+# binary was one Apple had not opened submissions for yet, and there is no flag
+# that changes that. The App Store build therefore belongs on a runner whose
+# Xcode is a released one — the same reason the Developer ID release already
+# builds here rather than locally.
+#
+# `release.yml` handles the notarised disk image on every `v*` tag. This is the
+# other channel and is deliberately manual: an App Store submission is a thing a
+# person decides to send, and the metadata it ships with has to be ready first.
+#
+#   gh workflow run "App Store build" -f tag=v0.18.0
+#
+# It does not attach the build to a version and does not submit anything. Apple
+# processes the upload, the build appears, and attaching plus submitting is the
+# App Store Connect API call that `docs/APP_STORE.md` describes.
+
+on:
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: "Tag to build (e.g. v0.18.0)"
+        required: true
+      build:
+        description: "Build number. Must be higher than every build already uploaded for this marketing version — Apple rejects a repeat, and the tag cannot be moved to bump it."
+        required: true
+
+permissions:
+  contents: read
+
+concurrency:
+  group: appstore-${{ github.event.inputs.tag }}
+  cancel-in-progress: false
+
+jobs:
+  upload:
+    name: Archive and upload to App Store Connect
+    runs-on: macos-15
+    timeout-minutes: 60
+    steps:
+      - name: Check the tag looks like a release
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          if [[ ! "$TAG" =~ ^v[0-9]+\.[0-9]+\.[0-9]+(-[0-9A-Za-z.-]+)?$ ]]; then
+            echo "::error::Tag must look like v0.18.0, got: $TAG" >&2
+            exit 1
+          fi
+
+      # Checked out at the dispatched ref, NOT at the tag — and then proved
+      # identical to the tag where it counts.
+      #
+      # The obvious version of this job checks out the tag. It does not work: the
+      # release tooling is fixed after a release goes out at least as often as
+      # before it, so the tag's copy of `scripts/` is the copy that failed. v0.18.0
+      # is tagged one commit before the export learned to sign without an Xcode
+      # account. Building the tag would run the broken script.
+      #
+      # So: build the current tooling, and refuse if the shipping SOURCE differs
+      # from the tag by one byte. Documentation and scripts may move; the app may
+      # not.
+      - uses: actions/checkout@11d5960a326750d5838078e36cf38b85af677262 # v4.4.0
+        with:
+          fetch-depth: 0
+
+      - name: The app source must be exactly the tag's
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin "refs/tags/$TAG:refs/tags/$TAG" 2>/dev/null || true
+          if ! git rev-parse -q --verify "refs/tags/$TAG" >/dev/null; then
+            echo "::error::no such tag: $TAG" >&2
+            exit 1
+          fi
+          if ! git diff --quiet "$TAG" HEAD -- App Packages project.yml ItsPaint.xcodeproj; then
+            echo "::error::the tree differs from $TAG in the app source:" >&2
+            git diff --stat "$TAG" HEAD -- App Packages project.yml ItsPaint.xcodeproj >&2
+            exit 1
+          fi
+          echo "app source matches $TAG"
+
+      # The same check release.yml makes, for the same reason: project.yml is the
+      # file a person edits and ItsPaint.xcodeproj is the file xcodebuild reads,
+      # and v0.16.2 is a tag with no release behind it because only the first was
+      # bumped.
+      - name: The tag must match the version in the tree
+        env:
+          TAG: ${{ github.event.inputs.tag }}
+        run: |
+          set -euo pipefail
+          EXPECTED="${TAG#v}"; EXPECTED="${EXPECTED%%-*}"
+          COMMITTED="$(grep -m1 'MARKETING_VERSION:' project.yml | sed 's/.*"\(.*\)".*/\1/')"
+          GENERATED="$(grep -m1 'MARKETING_VERSION = ' ItsPaint.xcodeproj/project.pbxproj | sed 's/.*= *//; s/;.*//')"
+          for got in "$COMMITTED" "$GENERATED"; do
+            if [[ "$got" != "$EXPECTED" ]]; then
+              echo "::error::the tree builds $got, the tag asks for $EXPECTED" >&2
+              exit 1
+            fi
+          done
+
+      # Pick the newest Xcode the image ships, and say which one, in the log, on
+      # every run. GitHub's stable images only carry RELEASED Xcodes, which is the
+      # whole property this job is here for — the local machine had one Xcode and
+      # it was a beta. The failure that caused was invisible until Apple sent an
+      # email about it, so the version goes in the log whether or not it works.
+      - name: Select and name the toolchain
+        run: |
+          set -euo pipefail
+          NEWEST="$(ls -d /Applications/Xcode_*.app 2>/dev/null | sort -V | tail -1)"
+          if [[ -n "$NEWEST" ]]; then
+            sudo xcode-select -s "$NEWEST/Contents/Developer"
+          fi
+          xcodebuild -version
+          xcodebuild -showsdks | grep -i macos
+
+      - name: Import the App Store signing identities
+        env:
+          CERT_P12: ${{ secrets.MACOS_APPSTORE_P12 }}
+          CERT_PASSWORD: ${{ secrets.MACOS_APPSTORE_PASSWORD }}
+          PROFILE: ${{ secrets.MACOS_APPSTORE_PROFILE }}
+        run: |
+          set -euo pipefail
+          for name in CERT_P12 CERT_PASSWORD PROFILE; do
+            if [[ -z "${!name:-}" ]]; then
+              echo "::error::secret $name is not set; nothing can be signed for the store" >&2
+              exit 1
+            fi
+          done
+
+          KEYCHAIN="$RUNNER_TEMP/appstore.keychain-db"
+          KEYCHAIN_PASSWORD="$(openssl rand -base64 24)"
+          P12="$RUNNER_TEMP/appstore.p12"
+
+          printf '%s' "$CERT_P12" | base64 --decode > "$P12"
+          security create-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security set-keychain-settings -lut 21600 "$KEYCHAIN"
+          security unlock-keychain -p "$KEYCHAIN_PASSWORD" "$KEYCHAIN"
+          security import "$P12" -k "$KEYCHAIN" -P "$CERT_PASSWORD" \
+            -T /usr/bin/codesign -T /usr/bin/productbuild -T /usr/bin/productsign -T /usr/bin/security
+          # Without this, codesign blocks on a UI prompt no one can answer.
+          security set-key-partition-list \
+            -S apple-tool:,apple:,codesign:,productbuild:,productsign: \
+            -s -k "$KEYCHAIN_PASSWORD" "$KEYCHAIN" >/dev/null
+          # Prepend rather than replace: dropping the login keychain takes the
+          # Apple intermediates with it and the chain stops validating.
+          security list-keychains -d user -s "$KEYCHAIN" \
+            $(security list-keychains -d user | sed -e 's/^ *//' -e 's/"//g')
+          rm -f "$P12"
+
+          mkdir -p "$HOME/Library/MobileDevice/Provisioning Profiles"
+          printf '%s' "$PROFILE" | base64 --decode \
+            > "$HOME/Library/MobileDevice/Provisioning Profiles/itspaint-appstore.provisionprofile"
+
+          # Both identities or nothing: the app is signed by one and the pkg by
+          # the other, and missing the installer one fails after the archive.
+          for want in "3rd Party Mac Developer Application" "3rd Party Mac Developer Installer"; do
+            if ! security find-identity -v "$KEYCHAIN" | grep -q "$want"; then
+              echo "::error::no '$want' identity in the imported certificate" >&2
+              security find-identity -v "$KEYCHAIN" >&2
+              exit 1
+            fi
+          done
+          security find-identity -v "$KEYCHAIN" | grep "3rd Party Mac Developer"
+
+      - name: Archive, export and upload
+        env:
+          ITSPAINT_TEAM_ID: ${{ secrets.NOTARY_TEAM_ID }}
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_PRIVATE_KEY: ${{ secrets.ASC_PRIVATE_KEY }}
+          BUILD: ${{ github.event.inputs.build }}
+        run: |
+          set -euo pipefail
+          # altool finds the key by id in one of a few fixed directories.
+          mkdir -p "$HOME/.appstoreconnect/private_keys"
+          printf '%s' "$ASC_PRIVATE_KEY" | base64 --decode \
+            > "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+
+          ITSPAINT_BUILD_NUMBER="$BUILD" scripts/appstore-archive.sh --upload
+
+          rm -f "$HOME/.appstoreconnect/private_keys/AuthKey_${ASC_KEY_ID}.p8"
+
+      - name: Say what to do next
+        run: |
+          echo "Uploaded. Apple processes the build in minutes; then attach it to"
+          echo "the version and submit — see docs/APP_STORE.md."

--- a/scripts/appstore-archive.sh
+++ b/scripts/appstore-archive.sh
@@ -82,6 +82,17 @@ if [[ "$MODE" == "validate" ]]; then
   SIGNING=(CODE_SIGN_STYLE=Manual DEVELOPMENT_TEAM= CODE_SIGN_IDENTITY=-)
 fi
 
+# A build number the caller can raise without moving a tag.
+#
+# Apple refuses a build number it has already seen for a marketing version, and
+# the tag that pins the marketing version cannot be moved or deleted. Without
+# this, correcting a rejected upload costs a whole version number.
+BUILD_OVERRIDE=()
+if [[ -n "${ITSPAINT_BUILD_NUMBER:-}" ]]; then
+  BUILD_OVERRIDE=(CURRENT_PROJECT_VERSION="$ITSPAINT_BUILD_NUMBER")
+  echo "Build number overridden to $ITSPAINT_BUILD_NUMBER" >&2
+fi
+
 rm -rf dist/appstore
 mkdir -p dist/appstore
 
@@ -89,7 +100,7 @@ xcodebuild archive \
   -project ItsPaint.xcodeproj -scheme ItsPaint -configuration Release \
   -destination 'generic/platform=macOS' -archivePath "$ARCHIVE" \
   ARCHS="arm64 x86_64" ONLY_ACTIVE_ARCH=NO \
-  "${SIGNING[@]}" ${EXTRA[@]+"${EXTRA[@]}"}
+  "${SIGNING[@]}" ${BUILD_OVERRIDE[@]+"${BUILD_OVERRIDE[@]}"} ${EXTRA[@]+"${EXTRA[@]}"}
 
 # The asserts that App Store validation would otherwise fail remotely.
 APP="$ARCHIVE/Products/Applications/ItsPaint.app"


### PR DESCRIPTION
Build 16 was archived, signed, uploaded — and rejected:

> **ITMS-90301: This bundle is invalid** — Apple is not currently accepting
> applications built with this version of the OS.

Nothing about the archive was wrong. The machine that made it has exactly one
Xcode, a beta (26.6, 17F113), whose only macOS SDK is a beta SDK, and the SDK
is recorded in the binary. There is no flag that changes it. **My mistake: I
built the store binary on a laptop without checking what SDK it would stamp,
having just verified everything else about that build in detail.**

## The fix

A `workflow_dispatch` job on `macos-15`, where GitHub ships only released
Xcodes, selecting the newest and printing it every run — the failure was
invisible until Apple emailed about it, so the version goes in the log whether
or not it works.

Three things it does that the obvious version would get wrong:

- **It checks out the dispatched ref, not the tag, and then proves the app
  source is byte-identical to the tag.** Release tooling gets fixed after a
  release at least as often as before it: `v0.18.0` is tagged one commit before
  the export learned to sign without an Xcode account, so building the tag runs
  the broken script. Docs and scripts may move between the tag and the build;
  `App`, `Packages`, `project.yml` and `ItsPaint.xcodeproj` may not.
- **The build number is an input.** Apple refuses a build number it has already
  seen, and the tag that pins the marketing version cannot be moved or deleted,
  so without this a rejected upload costs a whole version number.
  `ITSPAINT_BUILD_NUMBER` overrides `CURRENT_PROJECT_VERSION` at archive time.
- **Both identities or nothing.** The app is signed by one certificate and the
  pkg by the other; missing the installer one fails *after* the archive, which
  is the shape that reads like a build problem.

It uploads and stops. Attaching the build to a version and submitting stays an
App Store Connect API call, because a submission is a thing a person decides to
send.

New secrets: `MACOS_APPSTORE_P12`, `MACOS_APPSTORE_PASSWORD`,
`MACOS_APPSTORE_PROFILE`, `ASC_KEY_ID`, `ASC_ISSUER_ID`, `ASC_PRIVATE_KEY`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)