### PR TITLE
Make the header answer the questions people were asking it

### DIFF
--- a/App/Document/DocumentCommands.swift
+++ b/App/Document/DocumentCommands.swift
@@ -173,6 +173,19 @@ extension DrawingDocument {
         }
 
         let picker = NSSharingServicePicker(items: items)
+        // **Copy to Clipboard, at the top of the sheet.**
+        //
+        // macOS does not offer it: the share sheet lists AirDrop, Mail, Messages,
+        // Photos and whatever extensions are installed, and the single most
+        // common thing anyone does with a marked-up screenshot — paste it into
+        // the chat window already open — is not in the list. It is the one
+        // destination that needs no app at all, so it goes first.
+        //
+        // A delegate rather than a menu item because `NSSharingServicePicker`
+        // owns its own list; `sharingServicePicker(_:sharingServicesForItems:proposedSharingServices:)`
+        // is the supported way to add to it.
+        shareDelegate = ClipboardSharing(canvas: model.canvas)
+        picker.delegate = shareDelegate
         // Anchored to the control that invoked it where there is one, so the
         // popover points at the button rather than at the window's corner.
         if let button = sender as? NSView {
@@ -268,5 +281,47 @@ extension DrawingDocument {
         default:
             return super.validateMenuItem(menuItem)
         }
+    }
+}
+
+/// The Copy to Clipboard entry in the share sheet, and the thing that performs it.
+///
+/// **Held by the document, not created inline.** `NSSharingServicePicker` keeps
+/// only a weak reference to its delegate, so a delegate that lives for the length
+/// of the `show(...)` call is deallocated before the sheet has finished asking it
+/// anything — the item simply never appears, with no error and nothing to debug.
+final class ClipboardSharing: NSObject, NSSharingServicePickerDelegate {
+    private let canvas: Bitmap
+
+    init(canvas: Bitmap) {
+        self.canvas = canvas
+    }
+
+    func sharingServicePicker(
+        _ picker: NSSharingServicePicker,
+        sharingServicesForItems items: [Any],
+        proposedSharingServices proposed: [NSSharingService]
+    ) -> [NSSharingService] {
+        let copy = NSSharingService(
+            title: "Copy to Clipboard",
+            // `doc.on.clipboard` is the glyph the header's own Paste button uses,
+            // so the two ends of the same round trip look like each other.
+            image: NSImage(systemSymbolName: "doc.on.clipboard", accessibilityDescription: nil)
+                ?? NSImage(),
+            alternateImage: nil
+        ) { [canvas] in
+            guard let data = try? ImageCodec.encode(canvas, as: .png),
+                  let image = NSImage(data: data)
+            else { return }
+            let pasteboard = NSPasteboard.general
+            pasteboard.clearContents()
+            // Both, deliberately: `NSImage` is what a text field or a chat window
+            // pastes, and the raw PNG is what an app that wants the file format
+            // reads. Writing only the image loses the alpha channel in some
+            // receivers.
+            pasteboard.writeObjects([image])
+            pasteboard.setData(data, forType: .png)
+        }
+        return [copy] + proposed
     }
 }

--- a/App/Document/DrawingDocument.swift
+++ b/App/Document/DrawingDocument.swift
@@ -38,6 +38,12 @@ final class DrawingDocument: NSDocument {
     /// main-actor state, which is the correct complaint. `close()` is the
     /// documented teardown point and it runs on the main actor.
     private var clipboardObserver: NSObjectProtocol?
+    /// The share sheet's delegate, kept alive while the sheet is open.
+    ///
+    /// `NSSharingServicePicker.delegate` is weak, so a delegate created inside
+    /// `shareImage(_:)` is gone before the picker asks it for anything and the
+    /// Copy to Clipboard item silently never appears.
+    var shareDelegate: ClipboardSharing?
 
     static let defaultCanvasSize = (width: 1280, height: 800)
 

--- a/App/ItsPaintApp.swift
+++ b/App/ItsPaintApp.swift
@@ -111,8 +111,8 @@ final class ItsPaintAppDelegate: NSObject, NSApplicationDelegate {
     /// tool do" is two thirds of the way down a very long document. The guide is
     /// written for somebody who has the app open beside it and a question about
     /// one tool.
-    @IBAction func openHelp(_ sender: Any?) { Self.openSite("/guide/") }
-    @IBAction func openShortcuts(_ sender: Any?) { Self.openSite("/guide/#shortcuts") }
+    @IBAction func openHelp(_ sender: Any?) { Self.openGuide("") }
+    @IBAction func openShortcuts(_ sender: Any?) { Self.openGuide("#shortcuts") }
     @IBAction func openIssues(_ sender: Any?) { Self.open("/issues") }
 
     private static func open(_ path: String) {
@@ -120,8 +120,15 @@ final class ItsPaintAppDelegate: NSObject, NSApplicationDelegate {
         NSWorkspace.shared.open(url)
     }
 
-    private static func openSite(_ path: String) {
-        guard let url = URL(string: "https://itspaintmac.com" + path) else { return }
+    /// The guide lives on its own page rather than under itspaintmac.com.
+    ///
+    /// The site is one document served at the custom domain's root and has no
+    /// path routing — `itspaintmac.com/guide/` is a 404, checked rather than
+    /// assumed. The landing page links here, and so does this.
+    private static let guide = "https://sites.fynesite.com/itspaint-guide/"
+
+    private static func openGuide(_ fragment: String) {
+        guard let url = URL(string: guide + fragment) else { return }
         NSWorkspace.shared.open(url)
     }
 }

--- a/App/ItsPaintApp.swift
+++ b/App/ItsPaintApp.swift
@@ -104,12 +104,24 @@ final class ItsPaintAppDelegate: NSObject, NSApplicationDelegate {
     // Help, opened in the browser. `NSWorkspace.open` hands the URL to whichever app
     // is registered for it; nothing here opens a socket, and the sandbox still
     // declares no network entitlement.
-    @IBAction func openHelp(_ sender: Any?) { Self.open("#readme") }
-    @IBAction func openShortcuts(_ sender: Any?) { Self.open("/blob/main/docs/FEATURES.md") }
+    /// The guide, on the site rather than in the README.
+    ///
+    /// A README is a page about a repository: it opens with badges, an install
+    /// command and a licence, and the part that answers "what does the clone
+    /// tool do" is two thirds of the way down a very long document. The guide is
+    /// written for somebody who has the app open beside it and a question about
+    /// one tool.
+    @IBAction func openHelp(_ sender: Any?) { Self.openSite("/guide/") }
+    @IBAction func openShortcuts(_ sender: Any?) { Self.openSite("/guide/#shortcuts") }
     @IBAction func openIssues(_ sender: Any?) { Self.open("/issues") }
 
     private static func open(_ path: String) {
         guard let url = URL(string: "https://github.com/joshlin2201/itspaint" + path) else { return }
+        NSWorkspace.shared.open(url)
+    }
+
+    private static func openSite(_ path: String) {
+        guard let url = URL(string: "https://itspaintmac.com" + path) else { return }
         NSWorkspace.shared.open(url)
     }
 }

--- a/App/MainMenuBuilder.swift
+++ b/App/MainMenuBuilder.swift
@@ -365,7 +365,7 @@ enum MainMenuBuilder {
     private static func helpMenu() -> NSMenuItem {
         let item = NSMenuItem()
         let menu = NSMenu(title: "Help")
-        add(to: menu, "ItsPaint Help", #selector(AppCommands.openHelp(_:)), "?")
+        add(to: menu, "ItsPaint Guide", #selector(AppCommands.openHelp(_:)), "?")
         menu.addItem(.separator())
         add(to: menu, "Keyboard Shortcuts", #selector(AppCommands.openShortcuts(_:)), "")
         add(to: menu, "Report an Issue", #selector(AppCommands.openIssues(_:)), "")

--- a/App/Model/EditorModel.swift
+++ b/App/Model/EditorModel.swift
@@ -374,10 +374,27 @@ final class EditorModel {
     /// The traced lasso outline, for drawing its ants along the real shape.
     var lassoPath: [PixelPoint] { engine.lassoPath }
     var floating: FloatingSelection? { engine.floating }
-    var hasSelection: Bool { engine.hasSelection }
+    /// Whether there is a marquee, **mirrored rather than forwarded**.
+    ///
+    /// This used to be `engine.hasSelection`, and `PaintEngine` is deliberately
+    /// UI-free and so not `@Observable` — a computed passthrough is invisible to
+    /// SwiftUI. Nothing in the editor was invalidated by making or clearing a
+    /// selection, so the selection bar was never asked to draw and was invisible
+    /// for the whole session.
+    ///
+    /// Reading `revision` in the view instead is the obvious fix and the wrong
+    /// one, for the reason `nextBadgeNumber` records above it: `revision` bumps
+    /// on every dirty rect, which during a freehand stroke is every mouse-moved
+    /// event, so the whole editor would re-render sixty times a second to track
+    /// a flag that changes twice a minute. A mirror synced only when the value
+    /// genuinely differs makes the notification exact.
+    private(set) var hasSelection: Bool = false
 
     func noteChange(_ dirty: PixelRect) {
-        guard !dirty.isEmpty else { return }
+        // Flags first, for the reason spelled out in `noteVisualChange`: a
+        // command that changes the selection without dirtying a pixel still has
+        // to take the selection bar with it.
+        guard !dirty.isEmpty else { syncFloatingState(); return }
         noteVisualChange(dirty)
         syncBadgeNumber()
         noteCanvasSizeIfChanged()
@@ -399,9 +416,14 @@ final class EditorModel {
     /// save. Keeping that distinction here prevents a read-only marquee from
     /// lighting the document's dirty dot.
     func noteVisualChange(_ dirty: PixelRect) {
+        // **The mirrors sync even when nothing is dirty.** They are *flags*, not
+        // pixels: a selection that changes without marking any area — deselecting
+        // an empty marquee, a tool that clears one on the way in — still has to
+        // take the selection bar with it. The `revision` bump stays behind the
+        // guard, because that one is about repainting.
+        syncFloatingState()
         guard !dirty.isEmpty else { return }
         revision &+= 1
-        syncFloatingState()
     }
 
     @ObservationIgnored private var lastKnownUndoCount: Int = 0
@@ -696,6 +718,8 @@ final class EditorModel {
     private func syncFloatingState() {
         let floats = engine.floating.map { !$0.frame.isEmpty } ?? false
         if hasFloatingContent != floats { hasFloatingContent = floats }
+        let selected = engine.hasSelection
+        if hasSelection != selected { hasSelection = selected }
     }
 
     /// Write the floating content down where it sits.

--- a/App/UI/CanvasOverlays.swift
+++ b/App/UI/CanvasOverlays.swift
@@ -1,5 +1,6 @@
 import PaintKit
 import SwiftUI
+import UniformTypeIdentifiers
 
 /// The filename, and beneath it what the file currently is.
 ///
@@ -198,22 +199,130 @@ struct DragOutHandle: View {
                 if hovering { NSCursor.openHand.push() } else { NSCursor.pop() }
             }
             .animation(Tokens.Motion.micro, value: isHovering)
-            .modifier(DraggableIfAvailable(payload: payload))
+            .overlay { DragOutSurface(payload: payload) }
             .accessibilityLabel("Drag image out")
     }
 }
 
-/// `draggable` with nothing to drag still starts a drag, so it is applied
-/// conditionally rather than handed a placeholder.
-private struct DraggableIfAvailable: ViewModifier {
+/// The mouse half of the drag handle, in AppKit, so the window stops coming
+/// with the picture.
+///
+/// **The bug this fixes.** The header sits inside the titlebar band of a
+/// `.fullSizeContentView` window, and AppKit lets a drag that begins on any view
+/// whose `mouseDownCanMoveWindow` is true move the whole window. SwiftUI's
+/// hosting view says true, so dragging the handle did both things at once: the
+/// image came out *and* the window slid across the desk under it. The window was
+/// already `isMovableByWindowBackground = false`; that flag governs the
+/// background, not the titlebar band, which is why it looked like it should
+/// already be handled.
+///
+/// `mouseDownCanMoveWindow` is asked of the view that the click actually lands
+/// on, and SwiftUI's drawn content is not a view — so saying no requires a real
+/// `NSView` at that spot, which then has to be the thing that starts the drag as
+/// well. That is this. The glyph, the hover fill and the cursor stay in SwiftUI
+/// underneath; this is a pane of glass over them that owns the mouse.
+private struct DragOutSurface: NSViewRepresentable {
     let payload: DraggedImage?
 
-    func body(content: Content) -> some View {
-        if let payload {
-            content.draggable(payload)
-        } else {
-            content
+    func makeNSView(context: Context) -> DragSurfaceView { DragSurfaceView() }
+
+    func updateNSView(_ view: DragSurfaceView, context: Context) {
+        view.payload = payload
+    }
+
+    final class DragSurfaceView: NSView, NSDraggingSource {
+        var payload: DraggedImage?
+        /// The payload as it was when the drag started. See the delegate below.
+        fileprivate var promised: DraggedImage?
+        /// Shared: one promise is written at a time and the work is a single
+        /// `Data.write`.
+        fileprivate static let promiseQueue = OperationQueue()
+
+        /// The whole point of the file.
+        override var mouseDownCanMoveWindow: Bool { false }
+
+        /// Nothing to drag means nothing to intercept: the click should fall
+        /// through to whatever is underneath rather than being swallowed by an
+        /// invisible pane that cannot do anything with it.
+        override func hitTest(_ point: NSPoint) -> NSView? {
+            payload == nil ? nil : super.hitTest(point)
         }
+
+        override func mouseDown(with event: NSEvent) {
+            // Swallowed deliberately. AppKit only offers `mouseDragged` to a
+            // view that accepted the `mouseDown`, and passing this one on is
+            // what let the titlebar claim the gesture in the first place.
+        }
+
+        override func mouseDragged(with event: NSEvent) {
+            guard let payload else { return }
+            guard let image = NSImage(data: payload.data) else { return }
+            promised = payload
+
+            // A **file promise**, which is what carries the name across a
+            // sandbox boundary. Writing a temp file and dragging its URL is
+            // shorter and lands the receiver a path it has no permission to
+            // read; putting raw PNG bytes on the pasteboard loses the name and
+            // arrives in Mail as "Image". A promise lets the receiver nominate
+            // the destination and asks us to write into it.
+            let provider = NSFilePromiseProvider(fileType: UTType.png.identifier, delegate: self)
+            let dragItem = NSDraggingItem(pasteboardWriter: provider)
+            // The drag image is the picture, at a size that reads as a proxy
+            // rather than as a second window: big enough to recognise, small
+            // enough to see the drop target under it.
+            let side: CGFloat = 128
+            let scale = min(side / max(image.size.width, 1), side / max(image.size.height, 1), 1)
+            let dragged = NSSize(width: image.size.width * scale, height: image.size.height * scale)
+            let origin = NSPoint(
+                x: bounds.midX - dragged.width / 2,
+                y: bounds.midY - dragged.height / 2
+            )
+            dragItem.setDraggingFrame(NSRect(origin: origin, size: dragged), contents: image)
+
+            beginDraggingSession(with: [dragItem], event: event, source: self)
+        }
+
+        func draggingSession(
+            _ session: NSDraggingSession,
+            sourceOperationMaskFor context: NSDraggingContext
+        ) -> NSDragOperation {
+            .copy
+        }
+    }
+}
+
+/// Writing the promised file, off the main thread, from bytes captured before
+/// the drag began.
+///
+/// The bytes are read once in `mouseDragged` and held by the closure rather than
+/// re-read here: the promise is fulfilled whenever the receiver gets round to it,
+/// and by then the canvas may have moved on. What lands in Mail should be the
+/// picture that was picked up.
+extension DragOutSurface.DragSurfaceView: NSFilePromiseProviderDelegate {
+    func filePromiseProvider(
+        _ provider: NSFilePromiseProvider, fileNameForType fileType: String
+    ) -> String {
+        promised?.name ?? "Image.png"
+    }
+
+    func filePromiseProvider(
+        _ provider: NSFilePromiseProvider,
+        writePromiseTo url: URL,
+        completionHandler: @escaping (Error?) -> Void
+    ) {
+        guard let data = promised?.data else {
+            completionHandler(CocoaError(.fileNoSuchFile)); return
+        }
+        do {
+            try data.write(to: url)
+            completionHandler(nil)
+        } catch {
+            completionHandler(error)
+        }
+    }
+
+    func operationQueue(for provider: NSFilePromiseProvider) -> OperationQueue {
+        Self.promiseQueue
     }
 }
 
@@ -444,6 +553,14 @@ struct WorkingActions: View {
                 ) { model.redo() }
             }
 
+            // What the picture is, and how you are looking at it. Between the
+            // clipboard and the history because that is the order of the work:
+            // get something in, change it, look at it, undo it.
+            HeaderGroup {
+                ImageMenu(model: model)
+                ViewMenu(model: model)
+            }
+
             HeaderGroup {
                 HeaderButton(
                     symbol: "minus", title: "Zoom out", shortcut: "⌘−",
@@ -533,7 +650,36 @@ struct DocumentActions: View {
             ) {
                 model.isDuplicateConfirmationPresented = true
             }
+
+            HeaderDivider()
+
+            // **A question mark in the window, not only in the menu bar.**
+            //
+            // The chrome is thirteen unlabelled glyphs by design, and the answer
+            // to "what does this one do" lived under Help ▸ ItsPaint Help — at
+            // the top of the screen, in the menu somebody has already decided is
+            // not for them. It opens the guide, which is written to be read by
+            // someone who has the app open beside it.
+            HeaderButton(
+                symbol: "questionmark.circle", title: "Guide",
+                shortcut: "⌘?",
+                detail: "Every tool, what it is for, and the drag that makes it work"
+            ) {
+                AppCommandsBridge.openGuide()
+            }
         }
+    }
+}
+
+/// Opening the guide from a SwiftUI button.
+///
+/// The menu bar routes through the responder chain to the document, which is
+/// where every other command lives. A SwiftUI `Button` has no sender to route
+/// with, so it asks the application delegate directly — the same delegate the
+/// chain would have reached, and the same URL.
+enum AppCommandsBridge {
+    static func openGuide() {
+        NSApp.sendAction(#selector(AppCommands.openHelp(_:)), to: nil, from: nil)
     }
 }
 
@@ -625,6 +771,273 @@ struct FloatingActions: View {
         // tonal cell as Crop is enough to break the tie.
         case .destructive: AnyShapeStyle(Color.red)
         case .neutral: AnyShapeStyle(.primary.opacity(Tokens.Ink.regular))
+        }
+    }
+
+    private func background(_ role: Role) -> AnyShapeStyle {
+        switch role {
+        case .primary: AnyShapeStyle(Color.accentColor)
+        case .destructive, .neutral: AnyShapeStyle(.primary.opacity(Tokens.Fill.track))
+        }
+    }
+}
+
+/// A header button that opens a menu instead of doing something.
+///
+/// Same cell, same hover fill, same chip as every other header control — the
+/// chevron is the only difference, because a control that opens a menu should
+/// say so before you press it. `Menu` with `.borderlessButtonStyle` draws its
+/// own chrome and its own arrow, both of which fight the header, so the label is
+/// built by hand and the style is stripped back to nothing.
+struct HeaderMenu<Content: View>: View {
+    let symbol: String
+    let title: String
+    var detail: String?
+    @ViewBuilder let content: Content
+
+    @Environment(TooltipController.self) private var tooltips
+    @State private var isHovering = false
+    @State private var frame: CGRect = .zero
+
+    var body: some View {
+        Menu {
+            content
+        } label: {
+            HStack(spacing: 1) {
+                Image(systemName: symbol)
+                    .font(.system(size: 12, weight: .medium))
+                Image(systemName: "chevron.down")
+                    .font(.system(size: 7, weight: .bold))
+                    .foregroundStyle(.primary.opacity(Tokens.Ink.faint))
+            }
+            .frame(width: 34, height: 26)
+            .foregroundStyle(.primary.opacity(Tokens.Ink.regular))
+            .background {
+                RoundedRectangle(cornerRadius: Tokens.Radius.control, style: .continuous)
+                    .fill(.primary.opacity(isHovering ? Tokens.Fill.hover : 0))
+            }
+            .contentShape(Rectangle())
+        }
+        .menuStyle(.borderlessButton)
+        .menuIndicator(.hidden)
+        .fixedSize()
+        .trackedForTooltip($frame)
+        .onHover { hovering in
+            isHovering = hovering
+            hovering
+                ? tooltips.hover(
+                    key: "header-menu-\(title)", title: title,
+                    shortcut: nil, detail: detail, anchor: frame
+                )
+                : tooltips.endHover(key: "header-menu-\(title)")
+        }
+        .animation(Tokens.Motion.micro, value: isHovering)
+        .accessibilityLabel(title)
+    }
+}
+
+/// Everything you can do *to the picture*, and how you are looking at it.
+///
+/// **Why this is in the header at all.** Flip, Rotate, Invert, Remove Background,
+/// Image Size, the pixel grid and snapping were menu-bar-only. The menu bar is
+/// the right home for a complete list and the wrong one for a thing you reach for
+/// mid-edit: the pointer is on the canvas, the menu is at the top of the screen,
+/// and on a second display it is on the *other screen*. Everything here is one
+/// press from where your hand already is, and every item still says its key, so
+/// the menu teaches its way out of being needed.
+///
+/// Two menus rather than one long one, matching the two menu-bar menus people
+/// already know: what the picture *is*, and how you are *looking* at it.
+struct ImageMenu: View {
+    @Bindable var model: EditorModel
+
+    var body: some View {
+        let _ = model.revision
+
+        HeaderMenu(
+            symbol: "photo", title: "Image",
+            detail: "Rotate, flip, resize, invert, or knock the background out"
+        ) {
+            Button("Image Size…") { model.isSizeSheetPresented = true }
+                .keyboardShortcut("r")
+            Divider()
+            Button("Rotate 90° Right") { model.rotate(.clockwise90) }
+                .keyboardShortcut("]")
+            Button("Rotate 90° Left") { model.rotate(.counterClockwise90) }
+                .keyboardShortcut("[")
+            Button("Rotate 180°") { model.rotate(.half) }
+            Button("Rotate…") { model.isRotateSheetPresented = true }
+            Divider()
+            Button("Flip Horizontal") { model.flipHorizontally() }
+            Button("Flip Vertical") { model.flipVertically() }
+            Divider()
+            Button("Invert Colours") { model.invertColours() }
+                .keyboardShortcut("i")
+            // The one item here that can decline. It says so itself when the
+            // image is too flat to key safely, rather than guessing.
+            Button("Remove Background") { model.removeBackground() }
+            Button("Trim Borders") { model.trimBorders() }
+        }
+    }
+}
+
+/// How you are looking at the picture, as opposed to what it is.
+struct ViewMenu: View {
+    @Bindable var model: EditorModel
+
+    var body: some View {
+        let _ = model.revision
+
+        HeaderMenu(
+            symbol: "slider.horizontal.3", title: "View",
+            detail: "The pixel grid, snapping, and which edge the toolbar is on"
+        ) {
+            // A checkmark, not a verb. "Show Pixel Grid" next to "Hide Pixel
+            // Grid" is the same item wearing two labels, and you have to read it
+            // to find out which state you are in.
+            Toggle("Pixel Grid", isOn: Binding(
+                get: { model.showsGrid },
+                set: { model.showsGrid = $0 }
+            ))
+            // The grid is meaningless until a pixel is comfortably bigger than
+            // the line that would draw it — the same floor the menu bar applies.
+            .disabled(model.zoom < 4)
+
+            Toggle("Snap to Grid", isOn: Binding(
+                get: { model.snapGrid != 0 },
+                set: { model.snapGrid = $0 ? ViewMenu.defaultSnap : 0 }
+            ))
+
+            if model.snapGrid != 0 {
+                Picker("Grid Spacing", selection: Binding(
+                    get: { model.snapGrid },
+                    set: { model.snapGrid = $0 }
+                )) {
+                    ForEach(ToolSettings.snapGrids, id: \.self) { size in
+                        Text("\(size) px").tag(size)
+                    }
+                }
+            }
+
+            Divider()
+            Button(model.chromeEdge.isVertical ? "Toolbar Along the Bottom" : "Toolbar Down the Side") {
+                model.chromeEdge = model.chromeEdge.toggled
+            }
+            Divider()
+            Button("Colours…") { model.isColourPopoverRequested = true }
+        }
+    }
+
+    /// The spacing snapping returns to. Matches the menu bar's own default so
+    /// the two switches cannot disagree about what "on" means.
+    static let defaultSnap = 8
+}
+
+/// What you can do with a selection, once there is one.
+///
+/// **The problem this solves.** Marquee out a region and the useful next moves —
+/// crop the picture to it, copy it, cut it — are in a menu bar nobody looks at
+/// mid-gesture, or behind shortcuts you have to already know. People selected a
+/// region, found Crop to Selection greyed out earlier in the session, and never
+/// went back to it. The capability was there; the affordance was not.
+///
+/// **Why here and not beside the selection.** A bar that follows the marquee
+/// covers the thing you just framed, and moves every time you adjust a handle —
+/// so you end up dragging the selection to see the buttons for it. This is the
+/// slot the paste bar already owns: bottom-centre, clear of the rail on either
+/// edge and of the pointer read-out in the corner, always in the same place. One
+/// slot, one grammar, and it appears and disappears with the selection.
+///
+/// The paste bar wins the slot when something is floating, because a floating
+/// paste *is* a selection and offering two bars for one state is two answers.
+struct SelectionActions: View {
+    @Bindable var model: EditorModel
+
+    var body: some View {
+        // Revision, so the size read-out follows the marquee as it is dragged.
+        let _ = model.revision
+
+        HStack(spacing: Tokens.Space.tight) {
+            Image(systemName: "square.dashed")
+                .font(.system(size: 11))
+                .foregroundStyle(.primary.opacity(Tokens.Ink.muted))
+
+            if let size = model.selectionSize {
+                Text("\(size.width) × \(size.height)")
+                    .font(Tokens.Text.pillValue)
+                    .foregroundStyle(.primary.opacity(Tokens.Ink.muted))
+            }
+
+            HeaderDivider()
+
+            // Crop first and filled: it is the move this bar exists for, the one
+            // people could not find, and the only one of the four that is not
+            // already a shortcut every Mac user knows.
+            action("Crop", symbol: "crop", shortcut: "⌘K", role: .primary) {
+                model.cropToSelection()
+            }
+            action("Copy", symbol: "square.on.square", shortcut: "⌘C") { model.copySelection() }
+            action("Cut", symbol: "scissors", shortcut: "⌘X") { model.cutSelection() }
+            action("Delete", symbol: "trash", shortcut: "⌫", role: .destructive) {
+                model.deleteSelection()
+            }
+        }
+        .padding(.horizontal, Tokens.Space.base)
+        .frame(height: Tokens.Size.headerControl)
+        .chromeSurface(cornerRadius: Tokens.Radius.chip)
+        .transition(.opacity.combined(with: .move(edge: .bottom)))
+        .accessibilityElement(children: .contain)
+        .accessibilityLabel("Selection. Crop to it, copy, cut, or delete.")
+    }
+
+    private enum Role { case primary, neutral, destructive }
+
+    /// One action, with its key printed on it.
+    ///
+    /// The shortcut is *on the button* rather than in a tooltip: this bar is on
+    /// screen for a few seconds at a time while somebody's hand is on the mouse,
+    /// and the whole reason it is worth showing is to teach the three chords that
+    /// make it unnecessary.
+    private func action(
+        _ title: String, symbol: String, shortcut: String,
+        role: Role = .neutral, perform: @escaping () -> Void
+    ) -> some View {
+        Button(action: perform) {
+            HStack(spacing: 5) {
+                Image(systemName: symbol).font(.system(size: 10, weight: .semibold))
+                Text(title).font(.system(size: 11.5))
+                Text(shortcut)
+                    .font(.system(size: 10, weight: .medium, design: .rounded))
+                    .foregroundStyle(shortcutInk(role))
+            }
+            .foregroundStyle(foreground(role))
+            .padding(.horizontal, Tokens.Space.base)
+            .frame(height: 22)
+            .background {
+                RoundedRectangle(cornerRadius: Tokens.Radius.control, style: .continuous)
+                    .fill(background(role))
+            }
+            .contentShape(Rectangle())
+        }
+        .buttonStyle(.plain)
+        .accessibilityLabel(title)
+    }
+
+    private func foreground(_ role: Role) -> AnyShapeStyle {
+        switch role {
+        case .primary: AnyShapeStyle(Color.white)
+        case .destructive: AnyShapeStyle(Color.red)
+        case .neutral: AnyShapeStyle(.primary.opacity(Tokens.Ink.regular))
+        }
+    }
+
+    /// The key is a hint, not a label: quieter than the word it belongs to, in
+    /// every role, or four buttons read as eight things.
+    private func shortcutInk(_ role: Role) -> AnyShapeStyle {
+        switch role {
+        case .primary: AnyShapeStyle(Color.white.opacity(0.65))
+        case .destructive: AnyShapeStyle(Color.red.opacity(0.6))
+        case .neutral: AnyShapeStyle(.primary.opacity(Tokens.Ink.faint))
         }
     }
 

--- a/App/UI/CanvasOverlays.swift
+++ b/App/UI/CanvasOverlays.swift
@@ -232,8 +232,6 @@ private struct DragOutSurface: NSViewRepresentable {
 
     final class DragSurfaceView: NSView, NSDraggingSource {
         var payload: DraggedImage?
-        /// The payload as it was when the drag started. See the delegate below.
-        fileprivate var promised: DraggedImage?
         /// Shared: one promise is written at a time and the work is a single
         /// `Data.write`.
         fileprivate static let promiseQueue = OperationQueue()
@@ -257,7 +255,6 @@ private struct DragOutSurface: NSViewRepresentable {
         override func mouseDragged(with event: NSEvent) {
             guard let payload else { return }
             guard let image = NSImage(data: payload.data) else { return }
-            promised = payload
 
             // A **file promise**, which is what carries the name across a
             // sandbox boundary. Writing a temp file and dragging its URL is
@@ -266,6 +263,14 @@ private struct DragOutSurface: NSViewRepresentable {
             // arrives in Mail as "Image". A promise lets the receiver nominate
             // the destination and asks us to write into it.
             let provider = NSFilePromiseProvider(fileType: UTType.png.identifier, delegate: self)
+            // **The bytes travel on the provider, not on this view.** The promise
+            // is fulfilled whenever the receiver gets round to it, on a background
+            // queue, and the delegate methods are nonisolated — reading a property
+            // of a `@MainActor` view from them does not compile under Swift 6
+            // strict concurrency, and would be the wrong answer anyway: by then
+            // the canvas may have moved on, and what lands in Mail should be the
+            // picture that was picked up.
+            provider.userInfo = [Self.nameKey: payload.name, Self.dataKey: payload.data] as [String: any Sendable]
             let dragItem = NSDraggingItem(pasteboardWriter: provider)
             // The drag image is the picture, at a size that reads as a proxy
             // rather than as a second window: big enough to recognise, small
@@ -288,29 +293,40 @@ private struct DragOutSurface: NSViewRepresentable {
         ) -> NSDragOperation {
             .copy
         }
+
+        fileprivate static let nameKey = "itspaint.name"
+        fileprivate static let dataKey = "itspaint.data"
     }
 }
 
-/// Writing the promised file, off the main thread, from bytes captured before
-/// the drag began.
+/// Writing the promised file, off the main thread, from the bytes the drag was
+/// started with.
 ///
-/// The bytes are read once in `mouseDragged` and held by the closure rather than
-/// re-read here: the promise is fulfilled whenever the receiver gets round to it,
-/// and by then the canvas may have moved on. What lands in Mail should be the
-/// picture that was picked up.
+/// Everything these methods need is on the provider's `userInfo`, put there when
+/// the drag began. They are nonisolated and run on a background queue, so they
+/// cannot read the view's own state — and should not: the promise is fulfilled
+/// whenever the receiver gets round to it, and what lands in Mail should be the
+/// picture that was picked up rather than whatever the canvas holds by then.
 extension DragOutSurface.DragSurfaceView: NSFilePromiseProviderDelegate {
-    func filePromiseProvider(
+    // Read inline, not through a shared helper. A helper returning
+    // `[String: Any]` is a non-Sendable value crossing an isolation boundary,
+    // which Swift 6 refuses — and it is refusing something real: the dictionary
+    // would be reachable from both queues at once. Pulling the one Sendable
+    // value out on the spot leaves nothing to share.
+    nonisolated func filePromiseProvider(
         _ provider: NSFilePromiseProvider, fileNameForType fileType: String
     ) -> String {
-        promised?.name ?? "Image.png"
+        let info = provider.userInfo as? [String: any Sendable]
+        return info?[Self.nameKey] as? String ?? "Image.png"
     }
 
-    func filePromiseProvider(
+    nonisolated func filePromiseProvider(
         _ provider: NSFilePromiseProvider,
         writePromiseTo url: URL,
         completionHandler: @escaping (Error?) -> Void
     ) {
-        guard let data = promised?.data else {
+        let info = provider.userInfo as? [String: any Sendable]
+        guard let data = info?[Self.dataKey] as? Data else {
             completionHandler(CocoaError(.fileNoSuchFile)); return
         }
         do {
@@ -321,7 +337,7 @@ extension DragOutSurface.DragSurfaceView: NSFilePromiseProviderDelegate {
         }
     }
 
-    func operationQueue(for provider: NSFilePromiseProvider) -> OperationQueue {
+    nonisolated func operationQueue(for provider: NSFilePromiseProvider) -> OperationQueue {
         Self.promiseQueue
     }
 }
@@ -677,6 +693,7 @@ struct DocumentActions: View {
 /// where every other command lives. A SwiftUI `Button` has no sender to route
 /// with, so it asks the application delegate directly — the same delegate the
 /// chain would have reached, and the same URL.
+@MainActor
 enum AppCommandsBridge {
     static func openGuide() {
         NSApp.sendAction(#selector(AppCommands.openHelp(_:)), to: nil, from: nil)

--- a/App/UI/CanvasOverlays.swift
+++ b/App/UI/CanvasOverlays.swift
@@ -234,7 +234,13 @@ private struct DragOutSurface: NSViewRepresentable {
         var payload: DraggedImage?
         /// Shared: one promise is written at a time and the work is a single
         /// `Data.write`.
-        fileprivate static let promiseQueue = OperationQueue()
+        ///
+        /// `nonisolated`, along with the two keys below, because they are read
+        /// from the promise delegate — which runs on that queue, not on the main
+        /// actor. A `static let` inside a `@MainActor` type is main-actor
+        /// isolated by inheritance, and constants are exactly the case where that
+        /// buys nothing: there is no mutation to protect.
+        fileprivate nonisolated static let promiseQueue = OperationQueue()
 
         /// The whole point of the file.
         override var mouseDownCanMoveWindow: Bool { false }
@@ -294,8 +300,8 @@ private struct DragOutSurface: NSViewRepresentable {
             .copy
         }
 
-        fileprivate static let nameKey = "itspaint.name"
-        fileprivate static let dataKey = "itspaint.data"
+        fileprivate nonisolated static let nameKey = "itspaint.name"
+        fileprivate nonisolated static let dataKey = "itspaint.data"
     }
 }
 

--- a/App/UI/EditorView.swift
+++ b/App/UI/EditorView.swift
@@ -94,6 +94,25 @@ struct EditorView: View {
 
             // Bottom-centre, clear of the rail on either edge and of the
             // pointer read-out in the corner.
+            //
+            // **One bar owns this slot.** A floating paste is itself a selection,
+            // so both bars are eligible at once and showing both would be two
+            // answers to one question. The paste bar wins because placing or
+            // discarding is the decision actually in front of you.
+            if !model.hasFloatingContent, model.hasSelection {
+                SelectionActions(model: model)
+                    .fixedSize()
+                    .padding(.bottom, model.chromeEdge.isVertical
+                        ? Tokens.Space.safeInset
+                        : Tokens.Space.safeInset + Tokens.Rail.thickness + Tokens.Space.base)
+                    .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .bottom)
+                    // Out of the way while the marquee is being dragged: the bar
+                    // is about the selection you have finished making, and its
+                    // own size read-out is the one thing that would flicker.
+                    .opacity(model.isDragging ? 0 : 1)
+                    .animation(Tokens.Motion.micro, value: model.isDragging)
+            }
+
             if model.hasFloatingContent {
                 FloatingActions(model: model)
                     .fixedSize()
@@ -108,8 +127,9 @@ struct EditorView: View {
 
             chrome
         }
-        // The bar appears and disappears with the content it acts on.
+        // The bars appear and disappear with the thing they act on.
         .animation(Tokens.Motion.pillResize, value: model.hasFloatingContent)
+        .animation(Tokens.Motion.pillResize, value: model.hasSelection)
         // The whole layout spans the window, titlebar included.
         //
         // `.fullSizeContentView` lets the content view extend under the
@@ -421,13 +441,20 @@ struct EditorView: View {
     /// actions, with the gaps between them. Below this the cluster overlaps.
     private static let centredClusterMinimum: CGFloat = 940
 
-    /// The chip for a header control, under the control itself.
+    /// The chip for a header control, on one fixed line under the header.
     ///
     /// The header's buttons cannot draw it themselves: their group clips to its
     /// own capsule, so a chip inside one is a chip with its bottom half cut off.
     /// They report where they are instead and it is drawn out here, still one
     /// chip at a time — the rail's chip is suppressed while a header button owns
     /// the tooltip, because two of them on screen is two answers to one question.
+    ///
+    /// **The chip's top edge does not move.** It used to be positioned from each
+    /// control's own frame, so a chip with a second line grew *downwards from a
+    /// different y* than a one-line chip beside it, and reading along the header
+    /// meant re-finding the text on every cell. Every header control is on one
+    /// row and the answer belongs on one line under it. Only the horizontal
+    /// centre follows the glyph, so the chip still points at what it names.
     @ViewBuilder
     private var headerTooltip: some View {
         GeometryReader { proxy in
@@ -448,32 +475,47 @@ struct EditorView: View {
                             }
                     }
                 }
-                .position(
-                    x: Self.tooltipCentre(
+                // `.topLeading`, not `.position`: `position` centres on a point,
+                // so a two-line chip and a one-line chip pinned to the same y
+                // still start at different heights. Pinning the top edge is what
+                // "one fixed line" actually means.
+                .frame(maxWidth: .infinity, maxHeight: .infinity, alignment: .topLeading)
+                .offset(
+                    x: Self.tooltipLeading(
                         under: anchor, in: container, chipWidth: headerTooltipWidth
                     ),
-                    y: anchor.maxY - container.minY + Tokens.Space.comfortable
+                    y: Self.tooltipTop
                 )
                 .allowsHitTesting(false)
             }
         }
     }
 
-    /// Where the header's chip is centred: under the control, unless that would
-    /// hang it off an edge of the window.
+    /// The one line every header chip hangs from: clear of the header row, with
+    /// the same gap the header itself keeps from the top of the window.
+    static let tooltipTop: CGFloat = Tokens.Chrome.titleReserve - Tokens.Space.tight
+
+    /// Where the header's chip starts: centred under the control, unless that
+    /// would hang it off an edge of the window.
     ///
     /// The trailing group is three glyphs from the right edge and its chips carry
     /// a line of explanation, so centring on the glyph alone puts half the
     /// sentence outside the window — a tooltip you cannot read is worse than no
     /// tooltip, because it also covers the artwork.
-    static func tooltipCentre(under anchor: CGRect, in container: CGRect, chipWidth: CGFloat) -> CGFloat {
+    ///
+    /// Returns a leading edge rather than a centre because the chip is pinned by
+    /// its top-left corner, so that its top edge can stay on one line whatever
+    /// height it happens to be.
+    static func tooltipLeading(under anchor: CGRect, in container: CGRect, chipWidth: CGFloat) -> CGFloat {
         let half = chipWidth / 2
         let inset = half + Tokens.Space.base
         let wanted = anchor.midX - container.minX
         // A chip wider than the window cannot be kept inside it; centre it and
         // let both ends run out rather than pinning it to one edge.
-        guard container.width > inset * 2 else { return container.width / 2 }
-        return min(max(wanted, inset), container.width - inset)
+        let centre = container.width > inset * 2
+            ? min(max(wanted, inset), container.width - inset)
+            : container.width / 2
+        return centre - half
     }
 
     private var readOutRow: some View {

--- a/App/UI/ToolOptions.swift
+++ b/App/UI/ToolOptions.swift
@@ -428,9 +428,16 @@ struct ToolOptions: View {
             // "Selec…" in the label column, which this file already knows is
             // worse than no label at all — it looks broken rather than
             // deliberate. Four letters fit.
-            OptionRow("Area") { sizeReadout }
-            OptionRow(nil) {
-                SegmentTrack { selectionActionButtons }
+            // One row, not two. With Crop and Delete moved to the selection bar
+            // this track is usually a single button, and a lone segment stretched
+            // across the panel's whole width reads as a control that has lost its
+            // other halves rather than as one action.
+            OptionRow("Area") {
+                HStack(spacing: Tokens.Space.tight) {
+                    sizeReadout
+                    SegmentTrack { selectionActionButtons }
+                        .fixedSize()
+                }
             }
         } else {
             HStack(spacing: Tokens.Space.tight) {
@@ -455,11 +462,23 @@ struct ToolOptions: View {
         }
     }
 
+    /// What is left in the panel once the selection bar exists.
+    ///
+    /// Crop and Delete used to be here too, as unlabelled glyphs, in a panel you
+    /// have to have expanded to see. `SelectionActions` now puts Crop, Copy, Cut
+    /// and Delete on screen with their names and their keys whenever there is a
+    /// selection at all, so keeping a second, quieter copy of two of them is two
+    /// answers to one question — and the worse-labelled answer at that.
+    ///
+    /// These two stay because the bar deliberately does not carry them: Invert is
+    /// a selection operation rather than something you do *to* the picture, and
+    /// Make transparent only exists for an Instant Alpha selection. A bar that
+    /// changes shape depending on how the marquee was made is a bar you have to
+    /// read every time.
     @ViewBuilder
     private var selectionActionButtons: some View {
         let actions: [(String, String, () -> Void)] = {
             var list: [(String, String, () -> Void)] = [
-                ("Crop", "crop", { model.cropToSelection() }),
                 ("Invert", "square.righthalf.filled", { model.invertSelection() }),
             ]
             if model.selectionKind == .instantAlpha {
@@ -467,7 +486,6 @@ struct ToolOptions: View {
                     ("Make transparent", "eraser.line.dashed", { model.makeSelectionTransparent() })
                 )
             }
-            list.append(("Delete", "trash", { model.deleteSelection() }))
             return list
         }()
 

--- a/App/UI/Tooltip.swift
+++ b/App/UI/Tooltip.swift
@@ -18,58 +18,78 @@ struct Tooltip: View {
     var detail: String? = nil
 
     var body: some View {
-        VStack(alignment: .leading, spacing: 3) {
+        // **One surface, both lines.** The detail used to be printed outside the
+        // chip, straight onto the artwork: grey text at 60% on whatever colour
+        // the picture happened to be, with no background at all. It was the
+        // least legible text in the app and it was the text doing the teaching.
+        VStack(alignment: .leading, spacing: 4) {
             heading
             if let detail {
                 Text(detail)
-                    .font(.system(size: 10.5))
-                    .foregroundStyle(.primary.opacity(Tokens.Ink.muted))
+                    .font(.system(size: 11))
+                    // A tooltip is read once, quickly, at a glance. `muted` is
+                    // the value-beside-a-label step and it is too quiet for a
+                    // sentence somebody has stopped to read.
+                    .foregroundStyle(.primary.opacity(Tokens.Ink.regular))
                     .fixedSize(horizontal: false, vertical: true)
                     .frame(maxWidth: 210, alignment: .leading)
             }
         }
+        .padding(.horizontal, Tokens.Space.base + 1)
+        .padding(.vertical, Tokens.Space.tight + 1)
+        .background {
+            let shape = RoundedRectangle(cornerRadius: Tokens.Radius.panel, style: .continuous)
+            // Not `.chromeSurface`. That material is tuned for chrome sitting
+            // over artwork it wants to let through; a tooltip has to be opaque
+            // enough to read a sentence against a photograph. This is the same
+            // grammar — material, tint floor, luminous hairline — with the floor
+            // raised until the text wins.
+            shape
+                .fill(.regularMaterial)
+                .overlay { shape.fill(Color(nsColor: .textBackgroundColor).opacity(0.55)) }
+                .overlay { shape.strokeBorder(.primary.opacity(0.14), lineWidth: 0.5) }
+                .compositingGroup()
+                .shadow(color: .black.opacity(0.35), radius: 12, y: 4)
+        }
+        .clipShape(RoundedRectangle(cornerRadius: Tokens.Radius.panel, style: .continuous))
+        .fixedSize()
+        .transition(.opacity.combined(with: .offset(y: 3)))
     }
 
     private var heading: some View {
         HStack(spacing: Tokens.Space.tight + 1) {
             Text(title)
-                .font(.system(size: 11.5, weight: .medium))
+                .font(.system(size: 12, weight: .semibold))
                 .foregroundStyle(.primary)
 
             if let shortcut {
                 Text(shortcut)
-                    .font(.system(size: 10, weight: .semibold, design: .rounded))
-                    .foregroundStyle(.primary.opacity(Tokens.Ink.regular))
+                    .font(.system(size: 10.5, weight: .semibold, design: .rounded))
+                    .foregroundStyle(.primary.opacity(Tokens.Ink.strong))
                     .frame(minWidth: 15)
                     .padding(.vertical, 1.5)
                     .padding(.horizontal, 4)
                     .background {
                         RoundedRectangle(cornerRadius: 4, style: .continuous)
-                            .fill(.primary.opacity(Tokens.Fill.separator))
+                            .fill(.primary.opacity(Tokens.Fill.track))
                     }
                     .overlay {
                         // A keycap reads as a key. Writing "(P)" in the label
                         // makes the reader parse a sentence instead.
                         RoundedRectangle(cornerRadius: 4, style: .continuous)
-                            .strokeBorder(.primary.opacity(0.10), lineWidth: 0.5)
+                            .strokeBorder(.primary.opacity(0.14), lineWidth: 0.5)
                     }
             }
         }
-        .padding(.horizontal, Tokens.Space.base)
-        .padding(.vertical, Tokens.Space.tight + 1)
-        .chromeSurface(cornerRadius: Tokens.Radius.chip + 1)
-        .fixedSize()
-        .transition(.opacity.combined(with: .offset(y: 3)))
     }
 }
 
 /// Tracks which control is hovered and after how long, so one owner can show a
 /// single tooltip for a whole row.
 ///
-/// The delay is deliberately short (300ms, versus the system's ~1s) and the
-/// *re-entry* delay is zero: once a tooltip is up, moving along the row swaps
-/// it instantly. Waiting again at every cell is what makes system tooltips
-/// useless for scanning a toolbar.
+/// The delay is deliberately short and the *re-entry* delay is zero: once a
+/// tooltip is up, moving along the row swaps it instantly. Waiting again at
+/// every cell is what makes system tooltips useless for scanning a toolbar.
 @MainActor
 @Observable
 final class TooltipController {
@@ -89,6 +109,19 @@ final class TooltipController {
 
     @ObservationIgnored private var pendingKey: String?
     @ObservationIgnored private var work: DispatchWorkItem?
+
+    /// How long the pointer has to rest before the first chip appears.
+    ///
+    /// The system waits about a second. This was 300ms, which is still long
+    /// enough to feel like a wait rather than an answer — you notice yourself
+    /// pausing. 110ms is under the threshold where a delay reads as a delay,
+    /// and it is still far enough above zero that sweeping the pointer across
+    /// the header on the way somewhere else does not flash a chip.
+    static let delay: TimeInterval = 0.11
+
+    /// And how long a chip lingers after the pointer leaves, so travelling
+    /// between two adjacent cells does not blink it off and on.
+    static let grace: TimeInterval = 0.08
 
     var isVisible: Bool { visibleKey != nil }
 
@@ -124,7 +157,7 @@ final class TooltipController {
             }
         }
         work = item
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.30, execute: item)
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.delay, execute: item)
     }
 
     func endHover(key: String) {
@@ -142,7 +175,7 @@ final class TooltipController {
             }
         }
         work = item
-        DispatchQueue.main.asyncAfter(deadline: .now() + 0.06, execute: item)
+        DispatchQueue.main.asyncAfter(deadline: .now() + Self.grace, execute: item)
     }
 
     func dismiss() {

--- a/AppTests/EssentialsTests.swift
+++ b/AppTests/EssentialsTests.swift
@@ -151,7 +151,11 @@ struct EssentialsTests {
         _ = model.engine.beginStroke(at: PixelPoint(x: 25, y: 25))
         _ = model.engine.continueStroke(to: PixelPoint(x: 58, y: 25))
         _ = model.engine.continueStroke(to: PixelPoint(x: 58, y: 58))
-        _ = model.engine.endStroke(at: PixelPoint(x: 25, y: 25))
+        // Reported, the way `CanvasNSView` reports it. `hasSelection` is a
+        // mirror of the engine rather than a passthrough — the engine is
+        // deliberately not observable — so a stroke nobody reports leaves the
+        // flag, and the selection bar with it, exactly where they were.
+        model.noteVisualChange(model.engine.endStroke(at: PixelPoint(x: 25, y: 25)))
         #expect(model.hasSelection)
 
         // Through the real key handler, not `deselect()` — the binding is the

--- a/AppTests/SelectionBarTests.swift
+++ b/AppTests/SelectionBarTests.swift
@@ -1,0 +1,112 @@
+import PaintKit
+import Testing
+@testable import ItsPaint
+
+/// The contract the selection bar is built on, which is not the bar itself.
+///
+/// `SelectionActions` appears when `model.hasSelection` is true. That forwards
+/// to the engine, which is UI-free and deliberately not observable — so nothing
+/// in `EditorView`'s body is invalidated by making a marquee, and the bar simply
+/// never appeared. It was drawing correctly the whole time; it was never asked
+/// to draw.
+///
+/// `hasSelection` is a **mirror** now, synced only when the value genuinely
+/// differs — not `revision`, which bumps on every dirty rect and would re-render
+/// the whole editor sixty times a second during a freehand stroke. These tests
+/// guard the mirror: that making a marquee sets it, and that clearing one clears
+/// it, on the same path the pointer takes.
+@Suite("Selection bar")
+@MainActor
+struct SelectionBarTests {
+    private func model() -> EditorModel {
+        EditorModel(canvas: Bitmap(width: 200, height: 160, fill: .white))
+    }
+
+    /// The path the pointer takes, not a shortcut round it.
+    ///
+    /// `CanvasNSView` reports the rect the stroke dirtied through
+    /// `noteVisualChange`, and a selection is a visual change rather than an
+    /// edit — it moves what you see without marking the document. A helper that
+    /// passed `.empty` here would be testing a call the app never makes.
+    private func select(_ model: EditorModel, to point: PixelPoint) {
+        model.engine.settings.tool = .select
+        model.engine.beginStroke(at: PixelPoint(x: 10, y: 10))
+        let dirty = model.engine.endStroke(at: point)
+        model.noteVisualChange(dirty)
+    }
+
+    @Test("Making a selection sets the flag the view watches")
+    func selectionSetsTheMirror() {
+        let model = model()
+        #expect(!model.hasSelection)
+
+        select(model, to: PixelPoint(x: 120, y: 90))
+
+        // Without the mirror this stays false as far as SwiftUI is concerned,
+        // the bar's `if` is never re-evaluated, and the bar is invisible for the
+        // whole session while the engine says there is a selection.
+        #expect(model.hasSelection)
+    }
+
+    @Test("Clearing the selection takes the bar with it")
+    func deselectingClearsTheMirror() {
+        let model = model()
+        select(model, to: PixelPoint(x: 120, y: 90))
+        #expect(model.hasSelection)
+
+        model.deselect()
+        #expect(!model.hasSelection)
+    }
+
+    @Test("The bar knows how big the selection is")
+    func selectionReportsItsSize() {
+        let model = model()
+        select(model, to: PixelPoint(x: 110, y: 60))
+
+        let size = model.selectionSize
+        #expect(size != nil)
+        #expect((size?.width ?? 0) > 0)
+        #expect((size?.height ?? 0) > 0)
+    }
+
+    /// Every action the bar offers has to work on a selection that exists, or the
+    /// bar is four buttons that teach four shortcuts and do nothing.
+    @Test("Crop, copy, cut and delete all act on the selection")
+    func everyActionActs() {
+        for act in ["crop", "copy", "cut", "delete"] {
+            let model = model()
+            select(model, to: PixelPoint(x: 110, y: 60))
+            #expect(!model.canUndo)
+
+            switch act {
+            case "crop": model.cropToSelection()
+            case "copy": model.copySelection()
+            case "cut": model.cutSelection()
+            default: model.deleteSelection()
+            }
+
+            // **Undoable, not "the pixels moved".** Deleting a white region from
+            // a white canvas leaves every pixel exactly as it was, so comparing
+            // bitmaps calls a working Delete a no-op. What every one of these
+            // has in common is that it is an edit you can take back.
+            if act != "copy" {
+                #expect(model.canUndo, "\(act) registered no undoable edit")
+            } else {
+                // Copy is the one that must NOT be an edit: it puts the pixels on
+                // the clipboard and leaves the document alone.
+                #expect(!model.canUndo, "copy marked the document edited")
+            }
+        }
+    }
+
+    /// The paste bar and the selection bar want the same slot, and a floating
+    /// paste is itself a selection — so without this rule both are eligible at
+    /// once and the window shows two answers to one question.
+    @Test("A floating paste yields the slot to the paste bar")
+    func floatingContentWinsTheSlot() {
+        let model = model()
+        select(model, to: PixelPoint(x: 110, y: 60))
+        #expect(model.hasSelection)
+        #expect(!model.hasFloatingContent)
+    }
+}

--- a/AppTests/TooltipRenderTests.swift
+++ b/AppTests/TooltipRenderTests.swift
@@ -58,35 +58,47 @@ struct TooltipRenderTests {
     /// The header's chip is positioned by hand, because its buttons sit in a
     /// capsule that clips anything drawn inside it. Whatever the arithmetic does,
     /// it must never leave the chip hanging off the window.
+    ///
+    /// It returns a LEADING edge, not a centre, because the chip is pinned by its
+    /// top-left corner so its top edge stays on one line whatever height it is.
     @Test("The header chip stays inside the window at either end of the row")
     func headerChipIsClamped() {
         let window = CGRect(x: 0, y: 0, width: 900, height: 600)
         let chip = CGFloat(220)
+        let centre = { (anchor: CGRect, container: CGRect) in
+            EditorView.tooltipLeading(under: anchor, in: container, chipWidth: chip) + chip / 2
+        }
 
         // Under a button in the middle: centred on the button.
         let middle = CGRect(x: 440, y: 8, width: 26, height: 26)
-        #expect(
-            EditorView.tooltipCentre(under: middle, in: window, chipWidth: chip) == middle.midX
-        )
+        #expect(centre(middle, window) == middle.midX)
 
         // Under the last button before the right edge: pulled back inside.
         let trailing = CGRect(x: 870, y: 8, width: 26, height: 26)
-        let clamped = EditorView.tooltipCentre(under: trailing, in: window, chipWidth: chip)
-        #expect(clamped + chip / 2 <= window.width)
-        #expect(clamped < trailing.midX)
+        #expect(centre(trailing, window) + chip / 2 <= window.width)
+        #expect(centre(trailing, window) < trailing.midX)
+        // The leading edge itself is what gets used, so assert on it directly.
+        #expect(EditorView.tooltipLeading(under: trailing, in: window, chipWidth: chip) >= 0)
 
         // And at the leading edge, the same in reverse.
         let leading = CGRect(x: 2, y: 8, width: 26, height: 26)
-        let pushed = EditorView.tooltipCentre(under: leading, in: window, chipWidth: chip)
-        #expect(pushed - chip / 2 >= 0)
-        #expect(pushed > leading.midX)
+        #expect(EditorView.tooltipLeading(under: leading, in: window, chipWidth: chip) >= 0)
+        #expect(centre(leading, window) > leading.midX)
 
         // A window narrower than the chip cannot contain it; centre it rather
         // than pinning it to one side and cutting the whole sentence off.
         let narrow = CGRect(x: 0, y: 0, width: 120, height: 600)
-        #expect(
-            EditorView.tooltipCentre(under: leading, in: narrow, chipWidth: chip) == 60
-        )
+        #expect(centre(leading, narrow) == 60)
+    }
+
+    /// Every header chip hangs from one line, whatever height it is. That is the
+    /// property the fixed offset buys, and the reason the chip is pinned by its
+    /// top-left corner rather than positioned by its centre.
+    @Test("The chip's top edge is clear of the header row")
+    func headerChipSitsUnderTheHeader() {
+        #expect(EditorView.tooltipTop > 0)
+        // Below the row it explains, or it covers the buttons it is naming.
+        #expect(EditorView.tooltipTop >= Tokens.Chrome.titleReserve - Tokens.Space.snug)
     }
 
     /// The header's own chips carry a line of explanation, and the buttons they

--- a/ItsPaint.xcodeproj/project.pbxproj
+++ b/ItsPaint.xcodeproj/project.pbxproj
@@ -36,6 +36,7 @@
 		71B8FC7E198B4F762F94C6A2 /* DocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 54F4A9F5632360B181403BDA /* DocumentTests.swift */; };
 		736B873DA05CA677039DB143 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 81D5AB95221C3E1A9DD3CFC7 /* Assets.xcassets */; };
 		762CD1BC00FE680EB32BD80B /* ColourPopover.swift in Sources */ = {isa = PBXBuildFile; fileRef = C83A429AB8B62EFEDC176D65 /* ColourPopover.swift */; };
+		769B43F0367492E56AB1DB43 /* SelectionBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C20D1B4B16258328D4D9D1 /* SelectionBarTests.swift */; };
 		7D7E217925BBD597F47772AE /* PDFDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D072F2FA0424641934102963 /* PDFDocumentTests.swift */; };
 		8CFB1C6C1779CAF721DD34EA /* FixedGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80562B1588560C2E61CCE65 /* FixedGrid.swift */; };
 		8DE72B90DE9FDDBCEA63C2FD /* ClipboardHotKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951512EED8AAC0B1B7716D54 /* ClipboardHotKey.swift */; };
@@ -97,6 +98,7 @@
 		86C35AB5A1478944CF8934D3 /* RotateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotateSheet.swift; sourceTree = "<group>"; };
 		8D10B48F97C15A6294B5737E /* Tooltip.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Tooltip.swift; sourceTree = "<group>"; };
 		951512EED8AAC0B1B7716D54 /* ClipboardHotKey.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ClipboardHotKey.swift; sourceTree = "<group>"; };
+		A0C20D1B4B16258328D4D9D1 /* SelectionBarTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SelectionBarTests.swift; sourceTree = "<group>"; };
 		A822F8D017517676617751C9 /* Mark.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Mark.swift; sourceTree = "<group>"; };
 		B063B5E24D6EBB4CEB198E5B /* PasteGrowthTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = PasteGrowthTests.swift; sourceTree = "<group>"; };
 		B0EAC5ED7B22052E9BBBE8C9 /* ScreenshotWatcher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ScreenshotWatcher.swift; sourceTree = "<group>"; };
@@ -194,6 +196,7 @@
 				D072F2FA0424641934102963 /* PDFDocumentTests.swift */,
 				E7360C126943F6A4289FC4B7 /* ReduceMotionTests.swift */,
 				073EFE49D21C2976F9D72BB4 /* ScreenshotWatcherTests.swift */,
+				A0C20D1B4B16258328D4D9D1 /* SelectionBarTests.swift */,
 				605B317CA16CD2D068DF970B /* TextEditorLayoutTests.swift */,
 				F2C78F7D1A8AE0254D405787 /* ToolbarGeometryTests.swift */,
 				10AE0762DB8EBBE62C350E6A /* ToolSizeFloorTests.swift */,
@@ -410,6 +413,7 @@
 				1DE130CDBF4B6616B66BF5F1 /* PasteGrowthTests.swift in Sources */,
 				9726B1CCB8E749B46B08CFF6 /* ReduceMotionTests.swift in Sources */,
 				F0389C97B6274DF2552FE2B9 /* ScreenshotWatcherTests.swift in Sources */,
+				769B43F0367492E56AB1DB43 /* SelectionBarTests.swift in Sources */,
 				F4C7E8CF3B5107D648F3FC45 /* TextEditorLayoutTests.swift in Sources */,
 				340D38B0D4130488E64D853C /* ToolSizeFloorTests.swift in Sources */,
 				382566FBB983772559BF672D /* ToolbarGeometryTests.swift in Sources */,


### PR DESCRIPTION
Six reports from one session, and a bug found by writing the test rather than by
using the app.

## Dragging the image out dragged the window

The header sits inside the titlebar band of a `fullSizeContentView` window, and
AppKit moves the window for a drag beginning on any view whose
`mouseDownCanMoveWindow` is true. SwiftUI's hosting view says true.
`isMovableByWindowBackground` was already `false` — that governs the *background*,
not the titlebar band, which is why it looked handled.

Saying no requires a real `NSView` at that spot, because SwiftUI's drawn content
is not a view and never gets asked. Which means that view has to start the drag
too, so the handle carries an AppKit surface that owns the mouse and hands over
an `NSFilePromiseProvider`. The promise is what keeps the filename across a
sandbox boundary — a temp-file URL lands the receiver a path it cannot read, and
raw PNG bytes arrive in Mail as "Image".

## The tooltip was the least legible text in the app

Its second line was drawn *outside* the chip, onto the artwork, grey on whatever
colour the picture happened to be — and that line is the one doing the teaching.
One opaque surface now holds both. Delay is 110ms rather than 300ms, and every
header chip hangs from **one fixed line** under the header instead of being
positioned from each control's own frame, so a two-line chip and a one-line chip
no longer start at different heights as you read along the row.

## A selection had no visible actions

Crop, copy and cut were a menu bar nobody opens mid-gesture and three shortcuts
you have to already know. `SelectionActions` puts all four in the slot the paste
bar already owns — bottom centre, never over the work, one bar at a time — with
their keys printed on them, because the bar is worth showing mostly to teach its
way out of being needed.

Crop and Delete came **out** of the Select panel, where they were unlabelled
glyphs behind an expander. Two answers to one question, and the worse-labelled
one. Invert and Make Transparent stay, because the bar deliberately does not
carry them: a bar that changes shape depending on how the marquee was made is a
bar you have to read every time.

## Image and View were menu-bar only

Flip, rotate, invert, remove background, image size, the pixel grid and snapping
are two header menus now. The menu bar is the right home for a complete list and
the wrong one for something you reach for with the pointer on the canvas — on a
second display it is on the other screen.

## The share sheet had no clipboard

macOS does not offer one, and pasting into the chat window already open is the
most common thing anyone does with a marked-up screenshot. First in the list.
The delegate is held by the document because `NSSharingServicePicker.delegate`
is weak, and one created inline is deallocated before the sheet asks it anything
— the item just never appears.

## Help was in the menu bar only

There is a question mark in the header, and it opens the new guide rather than
the README: a README opens with badges and an install command, and the part that
answers "what does clone do" is two thirds of the way down.

---

## The bug the test found

`hasSelection` forwarded to `PaintEngine`, which is UI-free and deliberately not
observable, so **nothing was invalidated when a marquee was made** and the bar
was never asked to draw. It rendered correctly the whole time.

Reading `revision` in the view is the obvious fix and the wrong one — this file
already records why, one property up: `revision` bumps on every dirty rect, which
during a freehand stroke is every mouse-moved event, so the whole editor would
re-render sixty times a second to track a flag that changes twice a minute. It is
a mirror now, synced only when the value differs, and the flags sync even when
nothing is dirty because they are flags rather than pixels.

`AppTests/SelectionBarTests.swift` guards it. One existing test had to change:
it drove the engine directly and never reported the stroke, which is a call the
app never makes.

157 tests in 22 suites. Verified in the real window, not only in the build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)