### PR TITLE
Keep the window still under the drag-out handle, and lighten the light header

### DIFF
--- a/App/UI/CanvasOverlays.swift
+++ b/App/UI/CanvasOverlays.swift
@@ -29,9 +29,15 @@ struct DocumentTitle: View {
             // The subtitle carries what the document *is*, which is the thing
             // that used to sit in a floating strip over the bottom-right of
             // the artwork.
+            // `muted`, which the token file defines as "a value or read-out
+            // beside a label" — and this is the document's dimensions beside its
+            // name. It was `faint`, the hint step, and at 10.5pt over the light
+            // appearance's grey that measured about 2.4:1; `muted` measures about
+            // 4:1 light and 6:1 dark. `HeaderContrastTests` keeps it above the
+            // 3:1 floor in both appearances.
             Text(subtitle)
                 .font(.system(size: 10.5))
-                .foregroundStyle(.primary.opacity(Tokens.Ink.faint))
+                .foregroundStyle(.primary.opacity(Tokens.Ink.muted))
                 .lineLimit(1)
         }
         .accessibilityElement(children: .combine)
@@ -158,12 +164,6 @@ struct DragOutHandle: View {
     @State private var frame: CGRect = .zero
 
     var body: some View {
-        // Resolved before the gesture rather than inside it. `draggable` takes
-        // the payload up front, and there is no version of this that can hand
-        // over an empty PNG and call it a drag — if the encode fails the handle
-        // goes dim and refuses instead.
-        let payload = model.draggableImage()
-
         // `photo.on.rectangle.angled`, not an up-arrow. The first version used
         // `square.and.arrow.up.on.square`, which is a share glyph with a box
         // behind it — three cells from the real Share button and nearly
@@ -174,10 +174,10 @@ struct DragOutHandle: View {
         Image(systemName: "photo.on.rectangle.angled")
             .font(.system(size: 12, weight: .medium))
             .frame(width: 26, height: 26)
-            .foregroundStyle(.primary.opacity(payload == nil ? Tokens.Ink.disabled : Tokens.Ink.regular))
+            .foregroundStyle(.primary.opacity(Tokens.Ink.regular))
             .background {
                 RoundedRectangle(cornerRadius: Tokens.Radius.control, style: .continuous)
-                    .fill(.primary.opacity(isHovering && payload != nil ? Tokens.Fill.hover : 0))
+                    .fill(.primary.opacity(isHovering ? Tokens.Fill.hover : 0))
             }
             .contentShape(Rectangle())
             .trackedForTooltip($frame)
@@ -193,13 +193,16 @@ struct DragOutHandle: View {
                         anchor: frame
                     )
                     : tooltips.endHover(key: "header-drag")
-                guard payload != nil else { return }
                 // A grab cursor is the other half of the instruction: it says
                 // "drag me" before anyone has waited for any tooltip at all.
                 if hovering { NSCursor.openHand.push() } else { NSCursor.pop() }
             }
             .animation(Tokens.Motion.micro, value: isHovering)
-            .overlay { DragOutSurface(payload: payload) }
+            // The PNG is encoded when a drag actually begins, not on every render
+            // of the header: the header follows `revision`, and a full-canvas
+            // encode per hover or per resize frame was the cost of having the
+            // bytes ready for a drag that mostly never came.
+            .overlay { DragOutSurface(model: model) }
             .accessibilityLabel("Drag image out")
     }
 }
@@ -221,17 +224,30 @@ struct DragOutHandle: View {
 /// `NSView` at that spot, which then has to be the thing that starts the drag as
 /// well. That is this. The glyph, the hover fill and the cursor stay in SwiftUI
 /// underneath; this is a pane of glass over them that owns the mouse.
-private struct DragOutSurface: NSViewRepresentable {
-    let payload: DraggedImage?
+///
+/// **And the second half of it (issue #28).** That answer shipped in 0.19.0 and
+/// a report against 0.19.0 on macOS 26.5 said the window still came along. The
+/// flag is a request the titlebar honours *when the press reaches this view*: a
+/// press on a window that is not key does not reach any view unless the view
+/// accepts first mouse, and a picture is dragged out of a window that is behind
+/// Slack more often than out of the front one. So the surface accepts the first
+/// click — and, belt to those braces, tells the window at its own level that it
+/// cannot be moved at all for as long as the pointer is over the handle. A lock
+/// the frame checks before hit-testing anything does not depend on which view
+/// a given macOS decides the press landed on.
+struct DragOutSurface: NSViewRepresentable {
+    let model: EditorModel
 
     func makeNSView(context: Context) -> DragSurfaceView { DragSurfaceView() }
 
     func updateNSView(_ view: DragSurfaceView, context: Context) {
-        view.payload = payload
+        view.model = model
     }
 
     final class DragSurfaceView: NSView, NSDraggingSource {
-        var payload: DraggedImage?
+        /// Asked for the picture when a drag begins, so the encode happens once
+        /// per drag instead of once per render.
+        weak var model: EditorModel?
         /// Shared: one promise is written at a time and the work is a single
         /// `Data.write`.
         ///
@@ -245,11 +261,45 @@ private struct DragOutSurface: NSViewRepresentable {
         /// The whole point of the file.
         override var mouseDownCanMoveWindow: Bool { false }
 
-        /// Nothing to drag means nothing to intercept: the click should fall
-        /// through to whatever is underneath rather than being swallowed by an
-        /// invisible pane that cannot do anything with it.
-        override func hitTest(_ point: NSPoint) -> NSView? {
-            payload == nil ? nil : super.hitTest(point)
+        /// A drag proxy takes the first click. Without this, a press on the handle
+        /// of a window that is not key only activates the window, and the press
+        /// belongs to the titlebar — which moves the window with it.
+        override func acceptsFirstMouse(for event: NSEvent?) -> Bool { true }
+
+        /// The window-level lock. `activeAlways`, because the case it exists for is
+        /// a window that is not the active one.
+        override func updateTrackingAreas() {
+            super.updateTrackingAreas()
+            for area in trackingAreas { removeTrackingArea(area) }
+            addTrackingArea(NSTrackingArea(
+                rect: .zero,
+                options: [.mouseEnteredAndExited, .activeAlways, .inVisibleRect],
+                owner: self,
+                userInfo: nil
+            ))
+        }
+
+        override func mouseEntered(with event: NSEvent) { window?.isMovable = false }
+        override func mouseExited(with event: NSEvent) { window?.isMovable = true }
+
+        /// Restored whenever the gesture that needed the lock is over, and
+        /// re-armed if the pointer is still on the handle — a press without a
+        /// drag, or a drop back onto the handle itself, must not leave the window
+        /// stuck either way.
+        func releaseLock(pointerInWindow point: NSPoint?) {
+            guard let window else { return }
+            let inside = point.map { bounds.contains(convert($0, from: nil)) } ?? false
+            window.isMovable = !inside
+        }
+
+        override func mouseUp(with event: NSEvent) {
+            releaseLock(pointerInWindow: event.locationInWindow)
+        }
+
+        override func viewWillMove(toWindow newWindow: NSWindow?) {
+            // Leaving a window must leave it movable.
+            window?.isMovable = true
+            super.viewWillMove(toWindow: newWindow)
         }
 
         override func mouseDown(with event: NSEvent) {
@@ -259,7 +309,7 @@ private struct DragOutSurface: NSViewRepresentable {
         }
 
         override func mouseDragged(with event: NSEvent) {
-            guard let payload else { return }
+            guard let payload = model?.draggableImage() else { return }
             guard let image = NSImage(data: payload.data) else { return }
 
             // A **file promise**, which is what carries the name across a
@@ -298,6 +348,12 @@ private struct DragOutSurface: NSViewRepresentable {
             sourceOperationMaskFor context: NSDraggingContext
         ) -> NSDragOperation {
             .copy
+        }
+
+        func draggingSession(
+            _ session: NSDraggingSession, endedAt screenPoint: NSPoint, operation: NSDragOperation
+        ) {
+            releaseLock(pointerInWindow: window?.convertPoint(fromScreen: screenPoint))
         }
 
         fileprivate nonisolated static let nameKey = "itspaint.name"
@@ -485,9 +541,16 @@ struct HeaderDivider: View {
 /// white artwork would swallow the window controls. It fades out rather than
 /// ending on a hard line, so it reads as light falling off rather than a bar.
 struct TitlebarScrim: View {
+    @Environment(\.colorScheme) private var colorScheme
+
     var body: some View {
+        // Black falling off in dark appearance; the same rule inverted in light.
+        // One black scrim for both was issue #29: over the light appearance's
+        // pale grey it painted the top 64pt of every window a muddy mid-grey, and
+        // sat the title's black ink on the darkest band in the window.
+        let ink: Color = colorScheme == .dark ? .black : .white
         LinearGradient(
-            colors: [.black.opacity(0.34), .black.opacity(0)],
+            colors: [ink.opacity(0.34), ink.opacity(0)],
             startPoint: .top,
             endPoint: .bottom
         )

--- a/AppTests/DragOutGuardTests.swift
+++ b/AppTests/DragOutGuardTests.swift
@@ -1,0 +1,69 @@
+import AppKit
+import Testing
+@testable import ItsPaint
+
+/// The answers the drag-out surface gives the titlebar, and the lock it holds on
+/// the window while the pointer is over it. Issue #28: the window moved with the
+/// pointer on 0.19.0, which already said `mouseDownCanMoveWindow` was false —
+/// so the flag alone was not the guard, and this pins the rest of it.
+@Suite("Drag-out guard")
+@MainActor
+struct DragOutGuardTests {
+    private func surfaceInWindow() -> (NSWindow, DragOutSurface.DragSurfaceView) {
+        let window = NSWindow(
+            contentRect: NSRect(x: 0, y: 0, width: 300, height: 200),
+            styleMask: [.titled, .fullSizeContentView],
+            backing: .buffered,
+            defer: false
+        )
+        let view = DragOutSurface.DragSurfaceView(frame: NSRect(x: 10, y: 150, width: 26, height: 26))
+        window.contentView?.addSubview(view)
+        return (window, view)
+    }
+
+    private func enterExit(_ type: NSEvent.EventType, in window: NSWindow) throws -> NSEvent {
+        try #require(NSEvent.enterExitEvent(
+            with: type, location: NSPoint(x: 20, y: 160), modifierFlags: [], timestamp: 0,
+            windowNumber: window.windowNumber, context: nil, eventNumber: 0, trackingNumber: 0,
+            userData: nil
+        ))
+    }
+
+    @Test("The titlebar is told no, and the first click is taken")
+    func answersToTheTitlebar() {
+        let (_, view) = surfaceInWindow()
+        #expect(view.mouseDownCanMoveWindow == false)
+        #expect(view.acceptsFirstMouse(for: nil) == true)
+    }
+
+    @Test("The window is locked while the pointer is on the handle, and only then")
+    func locksTheWindowUnderThePointer() throws {
+        let (window, view) = surfaceInWindow()
+        #expect(window.isMovable)
+
+        view.mouseEntered(with: try enterExit(.mouseEntered, in: window))
+        #expect(window.isMovable == false)
+
+        // A press that ends on the handle keeps the lock: the pointer is still there.
+        view.releaseLock(pointerInWindow: NSPoint(x: 20, y: 160))
+        #expect(window.isMovable == false)
+
+        // A drop that lands elsewhere lets go.
+        view.releaseLock(pointerInWindow: NSPoint(x: 200, y: 20))
+        #expect(window.isMovable)
+
+        view.mouseEntered(with: try enterExit(.mouseEntered, in: window))
+        #expect(window.isMovable == false)
+        view.mouseExited(with: try enterExit(.mouseExited, in: window))
+        #expect(window.isMovable)
+    }
+
+    @Test("Leaving the window leaves it movable")
+    func leavingTheWindowUnlocksIt() throws {
+        let (window, view) = surfaceInWindow()
+        view.mouseEntered(with: try enterExit(.mouseEntered, in: window))
+        #expect(window.isMovable == false)
+        view.removeFromSuperview()
+        #expect(window.isMovable)
+    }
+}

--- a/AppTests/HeaderContrastTests.swift
+++ b/AppTests/HeaderContrastTests.swift
@@ -1,0 +1,71 @@
+import AppKit
+import Testing
+@testable import ItsPaint
+
+/// The dimensions read-out under the filename, against the well the window
+/// paints behind it. Issue #29 was the light appearance's version of this at
+/// about 2.4:1 — the hint step of the ink scale, at 10.5pt, on grey.
+///
+/// Measured off the real system colours for the appearance rather than off
+/// constants, so a macOS that repaints `underPageBackgroundColor` moves the
+/// number here too. 3:1 is the floor WCAG puts under any text at all; the
+/// values as of writing are about 4:1 light and 6:1 dark.
+@Suite("Header contrast")
+@MainActor
+struct HeaderContrastTests {
+    /// WCAG relative luminance of an opaque sRGB colour.
+    private static func luminance(_ colour: NSColor) -> Double {
+        let c = colour.usingColorSpace(.sRGB) ?? colour
+        func linear(_ channel: CGFloat) -> Double {
+            let v = Double(channel)
+            return v <= 0.03928 ? v / 12.92 : pow((v + 0.055) / 1.055, 2.4)
+        }
+        return 0.2126 * linear(c.redComponent) + 0.7152 * linear(c.greenComponent)
+            + 0.0722 * linear(c.blueComponent)
+    }
+
+    /// `ink` at `opacity` composited over an opaque `background`, as the eye sees it.
+    /// `labelColor` carries its own alpha, which is part of the answer.
+    private static func composite(_ ink: NSColor, opacity: Double, over background: NSColor) -> NSColor {
+        let i = ink.usingColorSpace(.sRGB) ?? ink
+        let b = background.usingColorSpace(.sRGB) ?? background
+        let a = Double(i.alphaComponent) * opacity
+        func mix(_ x: CGFloat, _ y: CGFloat) -> CGFloat { CGFloat(a) * x + CGFloat(1 - a) * y }
+        return NSColor(
+            srgbRed: mix(i.redComponent, b.redComponent),
+            green: mix(i.greenComponent, b.greenComponent),
+            blue: mix(i.blueComponent, b.blueComponent),
+            alpha: 1
+        )
+    }
+
+    /// Contrast of the subtitle's ink at `opacity` in the named appearance.
+    static func subtitleContrast(at opacity: Double, in appearance: NSAppearance.Name) -> Double {
+        var ratio = 0.0
+        NSAppearance(named: appearance)?.performAsCurrentDrawingAppearance {
+            let well = NSColor.underPageBackgroundColor
+            let text = composite(.labelColor, opacity: opacity, over: well)
+            let lighter = max(luminance(text), luminance(well))
+            let darker = min(luminance(text), luminance(well))
+            ratio = (lighter + 0.05) / (darker + 0.05)
+        }
+        return ratio
+    }
+
+    @Test("The dimensions read-out clears 3:1 in the light appearance")
+    func legibleInLight() {
+        #expect(Self.subtitleContrast(at: Tokens.Ink.muted, in: .aqua) >= 3)
+    }
+
+    @Test("The dimensions read-out clears 3:1 in the dark appearance")
+    func legibleInDark() {
+        #expect(Self.subtitleContrast(at: Tokens.Ink.muted, in: .darkAqua) >= 3)
+    }
+
+    /// Positive control: the step it replaced has to fail this, or the check
+    /// would have passed the bug it exists for.
+    @Test("The hint step it replaced did not clear it in light")
+    func theOldStepFails() {
+        #expect(Self.subtitleContrast(at: Tokens.Ink.faint, in: .aqua) < 3)
+    }
+}

--- a/AppTests/WindowCaptureTests.swift
+++ b/AppTests/WindowCaptureTests.swift
@@ -57,6 +57,12 @@ struct WindowCaptureTests {
         // The title chip shows the document name; without a file URL the
         // capture would read "Untitled".
         document.fileURL = imageURL
+        // Light or dark on demand. A capture otherwise comes out in whichever
+        // appearance the machine happens to be set to, and the light one is the
+        // one nobody was looking at (issue #29).
+        if let appearance = environment["ITSPAINT_CAPTURE_APPEARANCE"] {
+            NSApp.appearance = NSAppearance(named: appearance == "light" ? .aqua : .darkAqua)
+        }
         document.makeWindowControllers()
         document.showWindows()
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ version may still carry breaking changes to the document format.
 
 ## [Unreleased]
 
-## [0.20.0] — 2026-08-27
+## [0.20.0] — 2026-09-01
 
 ### Added
 - **A transparent colour actually paints now — and it rubs paint out.** The app
@@ -80,6 +80,26 @@ version may still carry breaking changes to the document format.
 - **VoiceOver can reach every value again.** The options panel's step was
   `max(range / 100, 1)`, which is one pixel on a size and the entire range on any
   0-to-1 fraction: Ink, Opacity and Strength had exactly two reachable values.
+- **Dragging the image out no longer moves the window on macOS 26 either**
+  ([#28](https://github.com/joshlin2201/itspaint/issues/28)). 0.19.0 put a real
+  AppKit view under the handle that answers no to the titlebar, and a report
+  against 0.19.0 said the window still came along. The flag is only honoured
+  when the press reaches that view — and a press on a window that is not the
+  front one does not reach any view unless it accepts the first click, which a
+  picture being dragged out from behind Slack is the ordinary case of. The
+  handle takes the first click now and, while the pointer is over it, tells the
+  window at its own level that it cannot be moved at all. The PNG is also encoded
+  when a drag begins rather than on every render of the header.
+- **The light appearance's header is not muddy any more**
+  ([#29](https://github.com/joshlin2201/itspaint/issues/29)). One black scrim
+  served both appearances; over the light appearance's pale grey it painted the
+  top of every window a mid-grey band and sat the title's black ink on the
+  darkest part of the window. The scrim is white in light now, black in dark —
+  the same rule the chrome's tint floor already follows. The dimensions read-out
+  under the filename moves from the hint step of the ink scale to the read-out
+  step, which is the step the token file defines it as: about 2.4:1 to about
+  4:1 against the well in light, and `HeaderContrastTests` keeps both
+  appearances above 3:1 off the real system colours.
 
 ## [0.19.0] — 2026-08-26
 

--- a/ItsPaint.xcodeproj/project.pbxproj
+++ b/ItsPaint.xcodeproj/project.pbxproj
@@ -39,6 +39,7 @@
 		736B873DA05CA677039DB143 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 81D5AB95221C3E1A9DD3CFC7 /* Assets.xcassets */; };
 		769B43F0367492E56AB1DB43 /* SelectionBarTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = A0C20D1B4B16258328D4D9D1 /* SelectionBarTests.swift */; };
 		7D7E217925BBD597F47772AE /* PDFDocumentTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = D072F2FA0424641934102963 /* PDFDocumentTests.swift */; };
+		817FD37CCF303AD0F635695E /* HeaderContrastTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = EB317884E619D72005B9DD11 /* HeaderContrastTests.swift */; };
 		8CFB1C6C1779CAF721DD34EA /* FixedGrid.swift in Sources */ = {isa = PBXBuildFile; fileRef = E80562B1588560C2E61CCE65 /* FixedGrid.swift */; };
 		8DE72B90DE9FDDBCEA63C2FD /* ClipboardHotKey.swift in Sources */ = {isa = PBXBuildFile; fileRef = 951512EED8AAC0B1B7716D54 /* ClipboardHotKey.swift */; };
 		924C2B7A35DD5F3985A29406 /* EssentialsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = C06E4A12B57303E5FE405DFC /* EssentialsTests.swift */; };
@@ -53,6 +54,7 @@
 		C8F6D5D56AB4B3B9C07FC626 /* Mark.swift in Sources */ = {isa = PBXBuildFile; fileRef = A822F8D017517676617751C9 /* Mark.swift */; };
 		CA7E69B188CC2D88EC2CE781 /* EditorModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 20B04711CAED447B409481B1 /* EditorModel.swift */; };
 		D00A7C03ECFC7BC4575AF104 /* SizeSheet.swift in Sources */ = {isa = PBXBuildFile; fileRef = F2ACA876E800C1AB89C90365 /* SizeSheet.swift */; };
+		EA37D532A83C3C3C131EBCC5 /* DragOutGuardTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 7E23B76494BE749548A4F36F /* DragOutGuardTests.swift */; };
 		F0389C97B6274DF2552FE2B9 /* ScreenshotWatcherTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 073EFE49D21C2976F9D72BB4 /* ScreenshotWatcherTests.swift */; };
 		F4C7E8CF3B5107D648F3FC45 /* TextEditorLayoutTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 605B317CA16CD2D068DF970B /* TextEditorLayoutTests.swift */; };
 /* End PBXBuildFile section */
@@ -95,6 +97,7 @@
 		6E86C21F2F8518B426159B77 /* EditorView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = EditorView.swift; sourceTree = "<group>"; };
 		7833326AD2D84AF29B6DE601 /* ToolRail.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolRail.swift; sourceTree = "<group>"; };
 		7B939C1CD497C7F8334FFD0B /* ItsPaintIntents.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ItsPaintIntents.swift; sourceTree = "<group>"; };
+		7E23B76494BE749548A4F36F /* DragOutGuardTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DragOutGuardTests.swift; sourceTree = "<group>"; };
 		81D5AB95221C3E1A9DD3CFC7 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		8468DB5919B3A21F63903298 /* CanvasOverlays.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CanvasOverlays.swift; sourceTree = "<group>"; };
 		86C35AB5A1478944CF8934D3 /* RotateSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RotateSheet.swift; sourceTree = "<group>"; };
@@ -115,6 +118,7 @@
 		E7360C126943F6A4289FC4B7 /* ReduceMotionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ReduceMotionTests.swift; sourceTree = "<group>"; };
 		E80562B1588560C2E61CCE65 /* FixedGrid.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FixedGrid.swift; sourceTree = "<group>"; };
 		EA6F6F30090979763C866F84 /* SignatureSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SignatureSheet.swift; sourceTree = "<group>"; };
+		EB317884E619D72005B9DD11 /* HeaderContrastTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = HeaderContrastTests.swift; sourceTree = "<group>"; };
 		F2ACA876E800C1AB89C90365 /* SizeSheet.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SizeSheet.swift; sourceTree = "<group>"; };
 		F2C78F7D1A8AE0254D405787 /* ToolbarGeometryTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ToolbarGeometryTests.swift; sourceTree = "<group>"; };
 		F61038BAA63756BDF531B7A0 /* WindowCaptureTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = WindowCaptureTests.swift; sourceTree = "<group>"; };
@@ -190,7 +194,9 @@
 			children = (
 				11CCE83773644C45A0171C62 /* CanvasRenderingTests.swift */,
 				54F4A9F5632360B181403BDA /* DocumentTests.swift */,
+				7E23B76494BE749548A4F36F /* DragOutGuardTests.swift */,
 				C06E4A12B57303E5FE405DFC /* EssentialsTests.swift */,
+				EB317884E619D72005B9DD11 /* HeaderContrastTests.swift */,
 				D830570256790D00CC81E37C /* HeaderGeometryTests.swift */,
 				CCB01892F8CC5C23F9945754 /* ImageServiceTests.swift */,
 				34D68AE3B45C7E5A426262AB /* IntentImageTests.swift */,
@@ -408,7 +414,9 @@
 			files = (
 				397D8480B03F1D4E483412F6 /* CanvasRenderingTests.swift in Sources */,
 				71B8FC7E198B4F762F94C6A2 /* DocumentTests.swift in Sources */,
+				EA37D532A83C3C3C131EBCC5 /* DragOutGuardTests.swift in Sources */,
 				924C2B7A35DD5F3985A29406 /* EssentialsTests.swift in Sources */,
+				817FD37CCF303AD0F635695E /* HeaderContrastTests.swift in Sources */,
 				50DD869D047AD6B3DBCA671F /* HeaderGeometryTests.swift in Sources */,
 				531FB0243541A216A57A5D38 /* ImageServiceTests.swift in Sources */,
 				A8567364BE05578FC20DCD4C /* IntentImageTests.swift in Sources */,


### PR DESCRIPTION
Fixes #28 and fixes #29, folded into the unreleased 0.20.0.

- The drag-out surface accepts first mouse and locks `window.isMovable` while the pointer is over it, released on exit, mouse-up or drop. The PNG is encoded when a drag begins, not per render.
- The titlebar scrim is white in the light appearance and black in dark. The dimensions read-out uses the read-out ink step.
- `DragOutGuardTests` pins the titlebar answers and the lock; `HeaderContrastTests` measures the subtitle against the real system colours in both appearances, with the old step as a positive control.
- `WindowCaptureTests` takes `ITSPAINT_CAPTURE_APPEARANCE`.