### PR TITLE
Make the numbers agree with 0.20.0

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -12,7 +12,7 @@ runs the whole engine suite:
 ```bash
 git clone https://github.com/joshlin2201/itspaint.git
 cd itspaint
-swift test          # 338 tests, 52 suites
+swift test          # 345 tests, 52 suites
 ```
 
 That is the entire loop for anything in `Packages/PaintKit/` — drawing, raster

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 Preview markup has no step badges, no pixelate and no drag-out.
 
-**3.46 MB** · free on the App Store · MIT ·
+**3.45 MB** · free on the App Store · MIT ·
 **no network entitlement, so the kernel refuses a socket**
 
 [![Release](https://img.shields.io/github/v/release/joshlin2201/itspaint?sort=semver&style=flat-square&label=release&color=2563eb)](https://github.com/joshlin2201/itspaint/releases)
@@ -32,7 +32,7 @@ brew install --cask joshlin2201/itspaint/itspaint
 
 ## What makes it different
 
-- **3.46 MB, and a window on screen in half a second.** Krita is a gigabyte and
+- **3.45 MB, and a window on screen in half a second.** Krita is a gigabyte and
   built for painters. CleanShot X is $29 plus a cloud subscription. Preview is
   already on your Mac and will not number a step or pixelate a token.
 - **No network entitlement.** `com.apple.security.network.client` is not requested,
@@ -57,7 +57,7 @@ a PNG with none of the app around it. No AppKit, no third-party dependency, **ma
 and up**.
 
 ```swift
-.package(url: "https://github.com/joshlin2201/itspaint", from: "0.19.0")
+.package(url: "https://github.com/joshlin2201/itspaint", from: "0.20.0")
 ```
 
 [![Swift versions](https://img.shields.io/endpoint?url=https%3A%2F%2Fswiftpackageindex.com%2Fapi%2Fpackages%2Fjoshlin2201%2Fitspaint%2Fbadge%3Ftype%3Dswift-versions)](https://swiftpackageindex.com/joshlin2201/itspaint)
@@ -175,7 +175,7 @@ to hear about a new build.
 | **Requires** | macOS 14 Sonoma or later |
 | **Architecture** | universal, one build for Apple silicon and Intel |
 | **Signing** | Developer ID, notarised, ticket stapled to the image *and* the app, so the check needs no network and there is nothing to clear from the Terminal |
-| **Download** | 3.46 MB for the disk image, with a SHA-256 in `checksums.txt` |
+| **Download** | 3.45 MB for the disk image, with a SHA-256 in `checksums.txt` |
 
 ```bash
 shasum -a 256 -c checksums.txt

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -17,7 +17,7 @@ with no UI framework and nothing third-party. The arrow never points the other
 way.
 
 This is what makes the whole tool matrix testable in milliseconds without
-launching an app — 338 engine tests cover it directly — and it means a UI
+launching an app — 345 engine tests cover it directly — and it means a UI
 redesign is a view-layer change rather than a rewrite. It has already survived
 one: the chrome was rebuilt from a floating cluster to a rail without the engine
 changing.

--- a/docs/TESTING.md
+++ b/docs/TESTING.md
@@ -1,6 +1,6 @@
 # Testing protocol
 
-495 tests cover the engine and the Mac app. This document explains what each
+519 tests cover the engine and the Mac app. This document explains what each
 suite is for, how to write a test that will still be useful in a year, and the
 three failure modes that have already cost a day each.
 


### PR DESCRIPTION
345 engine tests, 174 app tests, 519 in all, measured off CI run 33570018156 for 2ab095e. 3.45 MB disk image. Dependency example at 0.20.0.